### PR TITLE
Added configuration support. Resolves #1

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -1,0 +1,103 @@
+<?php
+namespace Zumba\Swivel;
+
+class Config implements ConfigInterface {
+
+    /**
+     * Index of the user's bucket
+     *
+     * @var integer
+     */
+    protected $index;
+
+    /**
+     * Map of features
+     *
+     * @var array
+     */
+    protected $map;
+
+    /**
+     * Zumba\Swivel\Config
+     *
+     * @param array $initialMap
+     * @param integer|null $index
+     */
+    public function __construct(array $initialMap = [], $index = null) {
+        $this->map = $initialMap;
+        $this->index = $index;
+    }
+
+    /**
+     * Add a feature to the config.
+     *
+     * @param string $slug
+     * @param array $buckets
+     * @return void
+     */
+    public function addFeature($slug, array $buckets) {
+        if (empty($this->map[$slug])) {
+            $this->map[$slug] = [];
+        }
+        $this->map[$slug] = array_merge($this->map[$slug], $buckets);
+    }
+
+    /**
+     * Add an array of features to the config.
+     *
+     * @param array $map Example: [ "A" => [1,2,3], "B" => [4,5,6] ]
+     * @return void
+     */
+    public function addFeatures(array $map) {
+        foreach ($map as $slug => $buckets) {
+            $this->addFeature($slug, $buckets);
+        }
+    }
+
+    /**
+     * Get a configured Bucket instance
+     *
+     * @return \Zumba\Swivel\Bucket
+     */
+    public function getBucket() {
+        $map = new Feature\Map($this->getMap());
+        return new Bucket($map, $this->index);
+    }
+
+    /**
+     * Get the configured feature map.
+     *
+     * @return array
+     */
+    public function getMap() {
+        return $this->map;
+    }
+
+    /**
+     * Remove a slug from the map.
+     *
+     * If $buckets is provided, will only remove the indicated buckets from the feature, not the
+     * entire slug.
+     *
+     * @param string $slug
+     * @param array $buckets
+     * @return void
+     */
+    public function removeFeature($slug, array $buckets = []) {
+        if (empty($buckets)) {
+            unset($this->map[$slug]);
+        } else if (isset($this->map[$slug])) {
+            $this->map[$slug] = array_values(array_diff($this->map[$slug], $buckets));
+        }
+    }
+
+    /**
+     * Set the bucket index for the user
+     *
+     * @param integer $index
+     * @return void
+     */
+    public function setBucket($index) {
+        $this->index = $index;
+    }
+}

--- a/src/ConfigInterface.php
+++ b/src/ConfigInterface.php
@@ -1,0 +1,56 @@
+<?php
+namespace Zumba\Swivel;
+
+interface ConfigInterface {
+
+    /**
+     * Add a feature to the config.
+     *
+     * @param string $slug
+     * @param array $buckets
+     * @return void
+     */
+    public function addFeature($slug, array $buckets);
+
+    /**
+     * Add an array of features to the config.
+     *
+     * @param array $map Example: [ "A" => [1,2,3], "B" => [4,5,6] ]
+     * @return void
+     */
+    public function addFeatures(array $map);
+
+    /**
+     * Get a configured Bucket instance
+     *
+     * @return \Zumba\Swivel\Bucket
+     */
+    public function getBucket();
+
+    /**
+     * Get the configured feature map.
+     *
+     * @return array
+     */
+    public function getMap();
+
+    /**
+     * Remove a slug from the map.
+     *
+     * If $buckets is provided, will only remove the indicated buckets from the feature, not the
+     * entire slug.
+     *
+     * @param string $slug
+     * @param array $buckets
+     * @return void
+     */
+    public function removeFeature($slug, array $buckets = []);
+
+    /**
+     * Set the bucket index for the user
+     *
+     * @param integer $index
+     * @return void
+     */
+    public function setBucket($index);
+}

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -14,10 +14,10 @@ class Manager implements ManagerInterface {
     /**
      * Zumba\Swivel\Manager
      *
-     * @param BucketInterface|null $bucket
+     * @param ConfigInterface $config
      */
-    public function __construct(BucketInterface $bucket = null) {
-        $this->setBucket($bucket);
+    public function __construct(ConfigInterface $config) {
+        $this->setBucket($config->getBucket());
     }
 
     /**

--- a/test/Tests/ConfigTest.php
+++ b/test/Tests/ConfigTest.php
@@ -1,0 +1,64 @@
+<?php
+namespace Tests;
+
+use \Zumba\Swivel\Config,
+    \Zumba\Swivel\Bucket;
+
+class ConfigTest extends \PHPUnit_Framework_TestCase {
+    public function testConstructorAddsEmptyMap() {
+        $config = new Config();
+        $this->assertEmpty($config->getMap());
+    }
+
+    public function testConstructorAddsMapParam() {
+        $map = ['Feature' => [1,2,3]];
+        $config = new Config($map);
+        $this->assertEquals($map, $config->getMap());
+    }
+
+    public function testAddFeature() {
+        $config = new Config();
+        $slug = 'Test';
+        $buckets = [1,2];
+        $config->addFeature($slug, $buckets);
+        $this->assertEquals($buckets, $config->getMap()[$slug]);
+    }
+
+    public function testAddFeatures() {
+        $config = new Config();
+        $features = [ 'A' => [1,2,3], 'B' => [4,5,6] ];
+        $config->addFeatures($features);
+        $this->assertEquals($features, $config->getMap());
+    }
+
+    public function testFeaturesAreCumulative() {
+        $config = new Config();
+        $features = [ 'A' => [1,2,3] ];
+        $config->addFeatures($features);
+        $config->addFeature('A', [9]);
+        $this->assertEquals([ 'A' => [1,2,3,9] ], $config->getMap());
+    }
+
+    public function testRemoveFeature() {
+        $config = new Config();
+        $features = [ 'A' => [1,2,3], 'B' => [4,5,6] ];
+        $config->addFeatures($features);
+        $config->removeFeature('B');
+        $this->assertEquals([ 'A' => [1,2,3] ], $config->getMap());
+    }
+
+    public function testRemoveFeatureBucketOnly() {
+        $config = new Config();
+        $features = [ 'A' => [1,2,3], 'B' => [4,5,6] ];
+        $config->addFeatures($features);
+        $config->removeFeature('B', [5]);
+        $this->assertEquals([ 'A' => [1,2,3], 'B' => [4,6] ], $config->getMap());
+    }
+
+    public function testGetBucket() {
+        $index = 4;
+        $config = new Config(['A' => [7,8,9]], 4);
+        $bucket = $config->getBucket();
+        $this->assertInstanceOf('Zumba\Swivel\Bucket', $bucket);
+    }
+}

--- a/test/Tests/ManagerTest.php
+++ b/test/Tests/ManagerTest.php
@@ -4,10 +4,11 @@ namespace Tests;
 use \Zumba\Swivel\Bucket;
 use \Zumba\Swivel\Feature\Builder;
 use \Zumba\Swivel\Manager;
+use \Zumba\Swivel\Config;
 
 class ManagerTest extends \PHPUnit_Framework_TestCase {
     public function testForFeature() {
-        $manager = new Manager();
+        $manager = new Manager($this->getMock('Zumba\Swivel\Config'));
         $map = $this->getMock('Zumba\Swivel\Feature\Map');
         $bucket = $this->getMock('Zumba\Swivel\Bucket', [], [$map]);
 
@@ -16,7 +17,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testSetBucketReturnsManager() {
-        $manager = new Manager();
+        $manager = new Manager($this->getMock('Zumba\Swivel\Config'));
         $map = $this->getMock('Zumba\Swivel\Feature\Map');
         $bucket = $this->getMock('Zumba\Swivel\Bucket', [], [$map]);
         $this->assertInstanceOf('Zumba\Swivel\Manager', $manager->setBucket($bucket));


### PR DESCRIPTION
This allows for easy configuration at the manager level when creating a new swivel manager.  Example:

``` php
$userBucket = 1; // from session
$featureMap = ['Feature' => [1,2,3], 'Feature.sub' => [1,2]]; // from db

$config = new \Zumba\Swivel\Config($featureMap, $userBucket);
$swivel = new \Zumba\Swivel\Manager($config);
```
