### PR TITLE
Added PSR-3 logger support.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         }
     ],
     "require": {
-        "php": ">=5.4"
+        "php": ">=5.4",
+        "psr/log": "1.0.*"
     },
     "require-dev": {
         "phpunit/phpunit": "4.4.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,47 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "57ffd44be4ad1350511d0365f46e2b42",
-    "packages": [],
+    "hash": "781f746cfc6319ca43c20f070502587b",
+    "packages": [
+        {
+            "name": "psr/log",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/fe0936ee26643249e916849d48e3a51d5f5e278b",
+                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Psr\\Log\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2012-12-21 11:40:51"
+        }
+    ],
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
@@ -261,16 +300,16 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "f8d5d08c56de5cfd592b3340424a81733259a876"
+                "reference": "db32c18eba00b121c145575fcbcd4d4d24e6db74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/f8d5d08c56de5cfd592b3340424a81733259a876",
-                "reference": "f8d5d08c56de5cfd592b3340424a81733259a876",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/db32c18eba00b121c145575fcbcd4d4d24e6db74",
+                "reference": "db32c18eba00b121c145575fcbcd4d4d24e6db74",
                 "shasum": ""
             },
             "require": {
@@ -283,7 +322,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3-dev"
+                    "dev-master": "1.4-dev"
                 }
             },
             "autoload": {
@@ -306,20 +345,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2014-08-31 06:12:13"
+            "time": "2015-01-17 09:51:32"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.4.1",
+            "version": "4.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "6a5e49a86ce5e33b8d0657abe145057fc513543a"
+                "reference": "e90575c2bb86290d57a262862dab1da125431576"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6a5e49a86ce5e33b8d0657abe145057fc513543a",
-                "reference": "6a5e49a86ce5e33b8d0657abe145057fc513543a",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e90575c2bb86290d57a262862dab1da125431576",
+                "reference": "e90575c2bb86290d57a262862dab1da125431576",
                 "shasum": ""
             },
             "require": {
@@ -377,7 +416,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2014-12-28 07:57:05"
+            "time": "2015-01-17 11:24:41"
         },
         {
             "name": "phpunit/phpunit-mock-objects",

--- a/src/Behavior.php
+++ b/src/Behavior.php
@@ -1,7 +1,12 @@
 <?php
 namespace Zumba\Swivel;
 
+use \Psr\Log\LoggerInterface,
+    \Psr\Log\NullLogger;
+
 class Behavior implements BehaviorInterface {
+
+    use \Psr\Log\LoggerAwareTrait;
 
     /**
      * Fully qualified feature slug
@@ -25,7 +30,8 @@ class Behavior implements BehaviorInterface {
      * @param string $slug
      * @param callable $strategy
      */
-    public function __construct($slug, callable $strategy) {
+    public function __construct($slug, callable $strategy, LoggerInterface $logger = null) {
+        $this->setLogger($logger ?: new NullLogger());
         $this->slug = $slug;
         $this->strategy = $strategy;
     }
@@ -38,6 +44,8 @@ class Behavior implements BehaviorInterface {
      * @see \Zumba\Swivel\BehaviorInterface
      */
     public function execute(array $args = []) {
+        $slug = $this->slug;
+        $this->logger->debug('Swivel - Executing behavior.', compact('slug', 'args'));
         return call_user_func_array($this->strategy, $args);
     }
 

--- a/src/BehaviorInterface.php
+++ b/src/BehaviorInterface.php
@@ -1,7 +1,7 @@
 <?php
 namespace Zumba\Swivel;
 
-interface BehaviorInterface {
+interface BehaviorInterface extends \Psr\Log\LoggerAwareInterface {
 
     /**
      * Execute the behavior's callable and return the result

--- a/src/Bucket.php
+++ b/src/Bucket.php
@@ -1,7 +1,13 @@
 <?php
 namespace Zumba\Swivel;
 
+use \Zumba\Swivel\Feature\MapInterface,
+    \Psr\Log\LoggerInterface,
+    \Psr\Log\NullLogger;
+
 class Bucket implements BucketInterface {
+
+    use \Psr\Log\LoggerAwareTrait;
 
     /**
      * Ordnial Bitmasks
@@ -48,7 +54,8 @@ class Bucket implements BucketInterface {
      * @param \Zumba\Swivel\Feature\MapInterface $featureMap
      * @param binary|null $index
      */
-    public function __construct(Feature\MapInterface $featureMap, $index = null) {
+    public function __construct(MapInterface $featureMap, $index = null, LoggerInterface $logger = null) {
+        $this->setLogger($logger ?: new NullLogger());
         $this->featureMap = $featureMap;
         $this->index = $index === null ? $this->randomIndex() : $index;
     }
@@ -71,6 +78,7 @@ class Bucket implements BucketInterface {
      */
     protected function randomIndex() {
         $key = $this->keys[$this->randomNumber()];
+        $this->logger->info('Swivel - Generated random bucket.', compact('key'));
         return constant("static::$key");
     }
 

--- a/src/BucketInterface.php
+++ b/src/BucketInterface.php
@@ -1,7 +1,7 @@
 <?php
 namespace Zumba\Swivel;
 
-interface BucketInterface {
+interface BucketInterface extends \Psr\Log\LoggerAwareInterface {
 
     /**
      * Check if a behavior is enabled for a particular context/bucket combination

--- a/src/Config.php
+++ b/src/Config.php
@@ -1,7 +1,12 @@
 <?php
 namespace Zumba\Swivel;
 
+use \Psr\Log\LoggerInterface,
+    \Psr\Log\NullLogger;
+
 class Config implements ConfigInterface {
+
+    use \Psr\Log\LoggerAwareTrait;
 
     /**
      * Index of the user's bucket
@@ -60,8 +65,9 @@ class Config implements ConfigInterface {
      * @return \Zumba\Swivel\Bucket
      */
     public function getBucket() {
-        $map = new Feature\Map($this->getMap());
-        return new Bucket($map, $this->index);
+        $logger = $this->getLogger();
+        $map = new Feature\Map($this->getFeatures(), $logger);
+        return new Bucket($map, $this->index, $logger);
     }
 
     /**
@@ -69,8 +75,17 @@ class Config implements ConfigInterface {
      *
      * @return array
      */
-    public function getMap() {
+    public function getFeatures() {
         return $this->map;
+    }
+
+    /**
+     * Get the PSR3 logger
+     *
+     * @return \Psr\Log\LoggerInterface|null
+     */
+    public function getLogger() {
+        return $this->logger ?: new NullLogger();
     }
 
     /**

--- a/src/ConfigInterface.php
+++ b/src/ConfigInterface.php
@@ -1,7 +1,7 @@
 <?php
 namespace Zumba\Swivel;
 
-interface ConfigInterface {
+interface ConfigInterface extends \Psr\Log\LoggerAwareInterface {
 
     /**
      * Add a feature to the config.
@@ -32,7 +32,14 @@ interface ConfigInterface {
      *
      * @return array
      */
-    public function getMap();
+    public function getFeatures();
+
+    /**
+     * Get the PSR3 logger
+     *
+     * @return \Psr\Log\LoggerInterface
+     */
+    public function getLogger();
 
     /**
      * Remove a slug from the map.

--- a/src/Feature/Builder.php
+++ b/src/Feature/Builder.php
@@ -1,10 +1,14 @@
 <?php
 namespace Zumba\Swivel\Feature;
 
-use Zumba\Swivel\BucketInterface,
-    Zumba\Swivel\Behavior;
+use \Zumba\Swivel\BucketInterface,
+    \Zumba\Swivel\Behavior,
+    \Psr\Log\LoggerInterface,
+    \Psr\Log\NullLogger;
 
 class Builder implements BuilderInterface {
+
+    use \Psr\Log\LoggerAwareTrait;
 
     const DEFAULT_SLUG = '__swivel_default';
 
@@ -49,7 +53,8 @@ class Builder implements BuilderInterface {
      * @param string $slug
      * @param BucketInterface $bucket
      */
-    public function __construct($slug, BucketInterface $bucket) {
+    public function __construct($slug, BucketInterface $bucket, LoggerInterface $logger = null) {
+        $this->setLogger($logger ?: new NullLogger());
         $this->slug = $slug;
         $this->bucket = $bucket;
     }
@@ -83,7 +88,9 @@ class Builder implements BuilderInterface {
      */
     public function defaultBehavior($strategy, array $args = []) {
         if ($this->defaultWaived) {
-            throw new \LogicException('Defined a default behavior after `noDefault` was called.');
+            $exception = new \LogicException('Defined a default behavior after `noDefault` was called.');
+            $this->logger->critical('Swivel', compact('exception'));
+            throw $exception;
         }
         if (!$this->behavior) {
             $this->setBehavior($this->getBehavior($strategy), $args);
@@ -110,6 +117,7 @@ class Builder implements BuilderInterface {
      * @return \Zumba\Swivel\BehaviorInterface
      */
     public function getBehavior($slug, $strategy = null) {
+        $this->logger->debug('Swivel - Creating new behavior.', compact('slug'));
         if (empty($strategy)) {
             $strategy = $slug;
             $slug = Behavior::DEFAULT_SLUG;
@@ -121,7 +129,7 @@ class Builder implements BuilderInterface {
             };
         }
         $slug = $this->slug . \Zumba\Swivel\Feature::DELIMITER . $slug;
-        return new Behavior($slug, $strategy);
+        return new Behavior($slug, $strategy, $this->logger);
     }
 
     /**
@@ -141,7 +149,9 @@ class Builder implements BuilderInterface {
      */
     public function noDefault() {
         if ($this->behavior && $this->behavior->getSlug() === static::DEFAULT_SLUG) {
-            throw new \LogicException('Called `noDefault` after a default behavior was defined.');
+            $exception = new \LogicException('Called `noDefault` after a default behavior was defined.');
+            $this->logger->critical('Swivel', compact('exception'));
+            throw $exception;
         }
         $this->defaultWaived = true;
         return $this;
@@ -155,6 +165,8 @@ class Builder implements BuilderInterface {
      * @return void
      */
     protected function setBehavior(Behavior $behavior, array $args = []) {
+        $slug = $behavior->getSlug();
+        $this->logger->debug('Swivel - Setting behavior.', compact('slug', 'args'));
         $this->behavior = $behavior;
         $this->args = $args;
     }

--- a/src/Feature/BuilderInterface.php
+++ b/src/Feature/BuilderInterface.php
@@ -1,7 +1,7 @@
 <?php
 namespace Zumba\Swivel\Feature;
 
-interface BuilderInterface {
+interface BuilderInterface extends \Psr\Log\LoggerAwareInterface {
 
     /**
      * Register a behavior

--- a/src/Feature/MapInterface.php
+++ b/src/Feature/MapInterface.php
@@ -1,7 +1,7 @@
 <?php
 namespace Zumba\Swivel\Feature;
 
-interface MapInterface {
+interface MapInterface extends \Psr\Log\LoggerAwareInterface {
 
     /**
      * Check if a feature slug is enabled for a particular bucket index

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -4,6 +4,8 @@ namespace Zumba\Swivel;
 
 class Manager implements ManagerInterface {
 
+    use \Psr\Log\LoggerAwareTrait;
+
     /**
      * A configured Bucket instance.
      *
@@ -17,7 +19,9 @@ class Manager implements ManagerInterface {
      * @param ConfigInterface $config
      */
     public function __construct(ConfigInterface $config) {
+        $this->setLogger($config->getLogger());
         $this->setBucket($config->getBucket());
+        $this->logger->debug('Swivel - Manager created.');
     }
 
     /**
@@ -28,7 +32,8 @@ class Manager implements ManagerInterface {
      * @see \Zumba\Swivel\ManagerInterface
      */
     public function forFeature($slug) {
-        return new Feature\Builder($slug, $this->bucket);
+        $this->logger->debug('Swivel - Generating builder for feature "' . $slug . '"');
+        return new Feature\Builder($slug, $this->bucket, $this->logger);
     }
 
     /**
@@ -41,7 +46,9 @@ class Manager implements ManagerInterface {
      * @see \Zumba\Swivel\ManagerInterface
      */
     public function invoke($slug, $a, $b = null) {
-        throw new \BadMethodCallException('Not Yet Implemented');
+        $exception = new \BadMethodCallException('Invoke Not Yet Implemented');
+        $this->logger->critical('Swivel', compact('exception'));
+        throw $exception;
     }
 
     /**
@@ -54,6 +61,7 @@ class Manager implements ManagerInterface {
     public function setBucket(BucketInterface $bucket = null) {
         if ($bucket) {
             $this->bucket = $bucket;
+            $this->logger->debug('Swivel - User bucket set.', compact('bucket'));
         }
         return $this;
     }

--- a/src/ManagerInterface.php
+++ b/src/ManagerInterface.php
@@ -1,7 +1,7 @@
 <?php
 namespace Zumba\Swivel;
 
-interface ManagerInterface {
+interface ManagerInterface extends \Psr\Log\LoggerAwareInterface {
 
     /**
      * Create a new Feature\Builder instance

--- a/test/Tests/ConfigTest.php
+++ b/test/Tests/ConfigTest.php
@@ -7,13 +7,13 @@ use \Zumba\Swivel\Config,
 class ConfigTest extends \PHPUnit_Framework_TestCase {
     public function testConstructorAddsEmptyMap() {
         $config = new Config();
-        $this->assertEmpty($config->getMap());
+        $this->assertEmpty($config->getFeatures());
     }
 
     public function testConstructorAddsMapParam() {
         $map = ['Feature' => [1,2,3]];
         $config = new Config($map);
-        $this->assertEquals($map, $config->getMap());
+        $this->assertEquals($map, $config->getFeatures());
     }
 
     public function testAddFeature() {
@@ -21,14 +21,14 @@ class ConfigTest extends \PHPUnit_Framework_TestCase {
         $slug = 'Test';
         $buckets = [1,2];
         $config->addFeature($slug, $buckets);
-        $this->assertEquals($buckets, $config->getMap()[$slug]);
+        $this->assertEquals($buckets, $config->getFeatures()[$slug]);
     }
 
     public function testAddFeatures() {
         $config = new Config();
         $features = [ 'A' => [1,2,3], 'B' => [4,5,6] ];
         $config->addFeatures($features);
-        $this->assertEquals($features, $config->getMap());
+        $this->assertEquals($features, $config->getFeatures());
     }
 
     public function testFeaturesAreCumulative() {
@@ -36,7 +36,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase {
         $features = [ 'A' => [1,2,3] ];
         $config->addFeatures($features);
         $config->addFeature('A', [9]);
-        $this->assertEquals([ 'A' => [1,2,3,9] ], $config->getMap());
+        $this->assertEquals([ 'A' => [1,2,3,9] ], $config->getFeatures());
     }
 
     public function testRemoveFeature() {
@@ -44,7 +44,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase {
         $features = [ 'A' => [1,2,3], 'B' => [4,5,6] ];
         $config->addFeatures($features);
         $config->removeFeature('B');
-        $this->assertEquals([ 'A' => [1,2,3] ], $config->getMap());
+        $this->assertEquals([ 'A' => [1,2,3] ], $config->getFeatures());
     }
 
     public function testRemoveFeatureBucketOnly() {
@@ -52,7 +52,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase {
         $features = [ 'A' => [1,2,3], 'B' => [4,5,6] ];
         $config->addFeatures($features);
         $config->removeFeature('B', [5]);
-        $this->assertEquals([ 'A' => [1,2,3], 'B' => [4,6] ], $config->getMap());
+        $this->assertEquals([ 'A' => [1,2,3], 'B' => [4,6] ], $config->getFeatures());
     }
 
     public function testGetBucket() {

--- a/test/Tests/Feature/BuilderTest.php
+++ b/test/Tests/Feature/BuilderTest.php
@@ -7,7 +7,7 @@ use \Zumba\Swivel\Feature;
 class BuilderTest extends \PHPUnit_Framework_TestCase {
     public function testAddBehavior() {
         $map = $this->getMock('Zumba\Swivel\Feature\Map');
-        $bucket = $this->getMock('Zumba\Swivel\Bucket', [], [$map]);
+        $bucket = $this->getMock('Zumba\Swivel\Bucket', ['enabled'], [$map]);
         $builder = $this->getMock('Zumba\Swivel\Feature\Builder', ['getBehavior'], ['Test', $bucket]);
         $strategy = function() {};
         $behavior = $this->getMock('Zumba\Swivel\Behavior', [], ['a', $strategy]);
@@ -28,7 +28,7 @@ class BuilderTest extends \PHPUnit_Framework_TestCase {
 
     public function testDefaultBehavior() {
         $map = $this->getMock('Zumba\Swivel\Feature\Map');
-        $bucket = $this->getMock('Zumba\Swivel\Bucket', [], [$map]);
+        $bucket = $this->getMock('Zumba\Swivel\Bucket', null, [$map]);
         $builder = $this->getMock('Zumba\Swivel\Feature\Builder', ['getBehavior'], ['Test', $bucket]);
         $strategy = function() {};
         $behavior = $this->getMock('Zumba\Swivel\Behavior', [], [Builder::DEFAULT_SLUG, $strategy]);
@@ -47,7 +47,7 @@ class BuilderTest extends \PHPUnit_Framework_TestCase {
      */
     public function testDefaultBehaviorThrowsIfNoDefaultCalledFirst() {
         $map = $this->getMock('Zumba\Swivel\Feature\Map');
-        $bucket = $this->getMock('Zumba\Swivel\Bucket', [], [$map]);
+        $bucket = $this->getMock('Zumba\Swivel\Bucket', null, [$map]);
         $builder = new Builder('Test', $bucket);
         $builder->noDefault();
         $builder->defaultBehavior(function() {});
@@ -58,7 +58,7 @@ class BuilderTest extends \PHPUnit_Framework_TestCase {
      */
     public function testNoDefaultThrowsIfDefaultBehaviorDefined() {
         $map = $this->getMock('Zumba\Swivel\Feature\Map');
-        $bucket = $this->getMock('Zumba\Swivel\Bucket', [], [$map]);
+        $bucket = $this->getMock('Zumba\Swivel\Bucket', null, [$map]);
         $builder = $this->getMock('Zumba\Swivel\Feature\Builder', ['getBehavior'], ['Test', $bucket]);
         $strategy = function() {};
         $behavior = $this->getMock('Zumba\Swivel\Behavior', ['getSlug'], [Builder::DEFAULT_SLUG, $strategy]);
@@ -69,7 +69,7 @@ class BuilderTest extends \PHPUnit_Framework_TestCase {
             ->will($this->returnValue($behavior));
 
         $behavior
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('getSlug')
             ->will($this->returnValue(Builder::DEFAULT_SLUG));
 
@@ -80,7 +80,7 @@ class BuilderTest extends \PHPUnit_Framework_TestCase {
 
     public function testExecute() {
         $map = $this->getMock('Zumba\Swivel\Feature\Map');
-        $bucket = $this->getMock('Zumba\Swivel\Bucket', [], [$map]);
+        $bucket = $this->getMock('Zumba\Swivel\Bucket', null, [$map]);
         $builder = $this->getMock('Zumba\Swivel\Feature\Builder', ['getFeature'], ['Test', $bucket]);
         $feature = $this->getMock('Zumba\Swivel\Feature');
 
@@ -99,7 +99,7 @@ class BuilderTest extends \PHPUnit_Framework_TestCase {
 
     public function testGetFeature() {
         $map = $this->getMock('Zumba\Swivel\Feature\Map');
-        $bucket = $this->getMock('Zumba\Swivel\Bucket', [], [$map]);
+        $bucket = $this->getMock('Zumba\Swivel\Bucket', ['enabled'], [$map]);
         $builder = $this->getMock('Zumba\Swivel\Feature\Builder', ['getBehavior'], ['Test', $bucket]);
         $strategy = function() {};
         $behavior = $this->getMock('Zumba\Swivel\Behavior', [], ['a', $strategy]);
@@ -122,7 +122,7 @@ class BuilderTest extends \PHPUnit_Framework_TestCase {
 
     public function testGetBehavior() {
         $map = $this->getMock('Zumba\Swivel\Feature\Map');
-        $bucket = $this->getMock('Zumba\Swivel\Bucket', [], [$map]);
+        $bucket = $this->getMock('Zumba\Swivel\Bucket', null, [$map]);
         $builder = new Builder('Test', $bucket);
         $strategy = function() {};
 

--- a/test/Tests/ManagerTest.php
+++ b/test/Tests/ManagerTest.php
@@ -8,18 +8,18 @@ use \Zumba\Swivel\Config;
 
 class ManagerTest extends \PHPUnit_Framework_TestCase {
     public function testForFeature() {
-        $manager = new Manager($this->getMock('Zumba\Swivel\Config'));
+        $manager = new Manager(new Config());
         $map = $this->getMock('Zumba\Swivel\Feature\Map');
-        $bucket = $this->getMock('Zumba\Swivel\Bucket', [], [$map]);
+        $bucket = $this->getMock('Zumba\Swivel\Bucket', null, [$map]);
 
         $manager->setBucket($bucket);
         $this->assertInstanceOf('Zumba\Swivel\Feature\Builder', $manager->forFeature('Test'));
     }
 
     public function testSetBucketReturnsManager() {
-        $manager = new Manager($this->getMock('Zumba\Swivel\Config'));
+        $manager = new Manager(new Config());
         $map = $this->getMock('Zumba\Swivel\Feature\Map');
-        $bucket = $this->getMock('Zumba\Swivel\Bucket', [], [$map]);
+        $bucket = $this->getMock('Zumba\Swivel\Bucket', null, [$map]);
         $this->assertInstanceOf('Zumba\Swivel\Manager', $manager->setBucket($bucket));
     }
 }


### PR DESCRIPTION
This PR adds support for injecting a PSR-3 logger into the configuration object, and sprinkles a few debug logs into the library.

``` php
$config = new \Zumba\Swivel\Config($map, $index, $logger);

// or

$config = new \Zumba\Swivel\Config($map, $index);
$config->setLogger($logger);
```
