### PR TITLE
Update Config and Map

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -59,7 +59,7 @@ class Config implements ConfigInterface {
      * @param integer $index
      * @return void
      */
-    public function setBucket($index) {
+    public function setBucketIndex($index) {
         $this->index = $index;
     }
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -18,45 +18,21 @@ class Config implements ConfigInterface {
     /**
      * Map of features
      *
-     * @var array
+     * @var \Zumba\Swivel\Map
      */
     protected $map;
 
     /**
      * Zumba\Swivel\Config
      *
-     * @param array $initialMap
+     * @param mixed $map
      * @param integer|null $index
+     * @param LoggerInterface|null $logger
      */
-    public function __construct(array $initialMap = [], $index = null) {
-        $this->map = $initialMap;
+    public function __construct($map = [], $index = null, LoggerInterface $logger = null) {
+        $this->setLogger($logger ?: $this->getLogger());
+        $this->setMap($map);
         $this->index = $index;
-    }
-
-    /**
-     * Add a feature to the config.
-     *
-     * @param string $slug
-     * @param array $buckets
-     * @return void
-     */
-    public function addFeature($slug, array $buckets) {
-        if (empty($this->map[$slug])) {
-            $this->map[$slug] = [];
-        }
-        $this->map[$slug] = array_merge($this->map[$slug], $buckets);
-    }
-
-    /**
-     * Add an array of features to the config.
-     *
-     * @param array $map Example: [ "A" => [1,2,3], "B" => [4,5,6] ]
-     * @return void
-     */
-    public function addFeatures(array $map) {
-        foreach ($map as $slug => $buckets) {
-            $this->addFeature($slug, $buckets);
-        }
     }
 
     /**
@@ -65,18 +41,7 @@ class Config implements ConfigInterface {
      * @return \Zumba\Swivel\Bucket
      */
     public function getBucket() {
-        $logger = $this->getLogger();
-        $map = new Map($this->getFeatures(), $logger);
-        return new Bucket($map, $this->index, $logger);
-    }
-
-    /**
-     * Get the configured feature map.
-     *
-     * @return array
-     */
-    public function getFeatures() {
-        return $this->map;
+        return new Bucket($this->map, $this->index, $this->getLogger());
     }
 
     /**
@@ -89,24 +54,6 @@ class Config implements ConfigInterface {
     }
 
     /**
-     * Remove a slug from the map.
-     *
-     * If $buckets is provided, will only remove the indicated buckets from the feature, not the
-     * entire slug.
-     *
-     * @param string $slug
-     * @param array $buckets
-     * @return void
-     */
-    public function removeFeature($slug, array $buckets = []) {
-        if (empty($buckets)) {
-            unset($this->map[$slug]);
-        } else if (isset($this->map[$slug])) {
-            $this->map[$slug] = array_values(array_diff($this->map[$slug], $buckets));
-        }
-    }
-
-    /**
      * Set the bucket index for the user
      *
      * @param integer $index
@@ -114,5 +61,26 @@ class Config implements ConfigInterface {
      */
     public function setBucket($index) {
         $this->index = $index;
+    }
+
+    /**
+     * Set the Zumba\Swivel\Map object
+     *
+     * @param mixed $map
+     * @return void
+     */
+    protected function setMap($map) {
+        $logger = $this->getLogger();
+        if (is_array($map)) {
+            $map = new Map($map, $logger);
+        } elseif ($map instanceof DriverInterface) {
+            $map = $map->getMap();
+            $map->setLogger($logger);
+        } elseif ($map instanceof MapInterface) {
+            $map->setLogger($logger);
+        } else {
+            throw new \LogicException('Invalid map passed to Zumba\Swivel\Config');
+        }
+        $this->map = $map;
     }
 }

--- a/src/ConfigInterface.php
+++ b/src/ConfigInterface.php
@@ -23,5 +23,5 @@ interface ConfigInterface extends \Psr\Log\LoggerAwareInterface {
      * @param integer $index
      * @return void
      */
-    public function setBucket($index);
+    public function setBucketIndex($index);
 }

--- a/src/ConfigInterface.php
+++ b/src/ConfigInterface.php
@@ -4,23 +4,6 @@ namespace Zumba\Swivel;
 interface ConfigInterface extends \Psr\Log\LoggerAwareInterface {
 
     /**
-     * Add a feature to the config.
-     *
-     * @param string $slug
-     * @param array $buckets
-     * @return void
-     */
-    public function addFeature($slug, array $buckets);
-
-    /**
-     * Add an array of features to the config.
-     *
-     * @param array $map Example: [ "A" => [1,2,3], "B" => [4,5,6] ]
-     * @return void
-     */
-    public function addFeatures(array $map);
-
-    /**
      * Get a configured Bucket instance
      *
      * @return \Zumba\Swivel\Bucket
@@ -28,30 +11,11 @@ interface ConfigInterface extends \Psr\Log\LoggerAwareInterface {
     public function getBucket();
 
     /**
-     * Get the configured feature map.
-     *
-     * @return array
-     */
-    public function getFeatures();
-
-    /**
      * Get the PSR3 logger
      *
      * @return \Psr\Log\LoggerInterface
      */
     public function getLogger();
-
-    /**
-     * Remove a slug from the map.
-     *
-     * If $buckets is provided, will only remove the indicated buckets from the feature, not the
-     * entire slug.
-     *
-     * @param string $slug
-     * @param array $buckets
-     * @return void
-     */
-    public function removeFeature($slug, array $buckets = []);
 
     /**
      * Set the bucket index for the user

--- a/src/DriverInterface.php
+++ b/src/DriverInterface.php
@@ -1,0 +1,11 @@
+<?php
+namespace Zumba\Swivel;
+
+interface DriverInterface extends \Psr\Log\LoggerAwareInterface {
+    /**
+     * Generate a Zumba\Swivel\MapInterface object
+     *
+     * @return \Zumba\Swivel\MapInterface
+     */
+    public function getMap();
+}

--- a/src/Map.php
+++ b/src/Map.php
@@ -52,7 +52,7 @@ class Map implements MapInterface {
             return $data;
         };
 
-        $maps = array_slice((func_get_args()), 1);
+        $maps = array_slice(func_get_args(), 1);
         $data = array_reduce($maps, $combine, $combine($this->map, $map->getMapData()));
         return new Map($data, $this->logger);
     }
@@ -133,7 +133,7 @@ class Map implements MapInterface {
      * @return MapInterface
      */
     public function merge(MapInterface $map) {
-        $maps = array_slice((func_get_args()), 1);
+        $maps = array_slice(func_get_args(), 1);
         $data = array_reduce($maps, 'array_merge', array_merge($this->map, $map->getMapData()));
         return new Map($data, $this->logger);
     }

--- a/src/MapInterface.php
+++ b/src/MapInterface.php
@@ -4,6 +4,29 @@ namespace Zumba\Swivel;
 interface MapInterface extends \Psr\Log\LoggerAwareInterface {
 
     /**
+     * Merge this map with another map and return a new MapInterface
+     *
+     * Values in $map will be added to values in this instance.  Any number of additional maps may
+     * be passed to this method, i.e. $map->merge($map2, $map3, $map4, ...);
+     *
+     * @param MapInterface $map
+     * @return MapInterface
+     */
+    public function add(MapInterface $map);
+
+    /**
+     * Compare $map to this instance and return a new MapInterface.
+     *
+     * Returned object will contain only the elements that differ between the two maps. If a feature
+     * with the same key has different buckets, the buckets from the passed-in $map will be in the
+     * new object.  If this map has a logger, it will be passed to the new map.
+     *
+     * @param MapInterface $map
+     * @return MapInterface
+     */
+    public function diff(MapInterface $map);
+
+    /**
      * Check if a feature slug is enabled for a particular bucket index
      *
      * @param string $slug
@@ -11,6 +34,35 @@ interface MapInterface extends \Psr\Log\LoggerAwareInterface {
      * @return boolean
      */
     public function enabled($slug, $index);
+
+    /**
+     * Get the internal map array used by this map object.
+     *
+     * @return array
+     */
+    public function getMapData();
+
+    /**
+     * Compare $map to this instance and return a new MapInterface.
+     *
+     * Returned object will contain only the elements that match between the two maps. If this map
+     * has a logger, it will be passed to the new map.
+     *
+     * @param MapInterface $map
+     * @return MapInterface
+     */
+    public function intersect(MapInterface $map);
+
+    /**
+     * Merge this map with another map and return a new MapInterface
+     *
+     * Values in $map will overwrite values in this instance.  Any number of additional maps may
+     * be passed to this method, i.e. $map->merge($map2, $map3, $map4, ...);
+     *
+     * @param MapInterface $map
+     * @return MapInterface
+     */
+    public function merge(MapInterface $map);
 
     /**
      * Parse a human readable map into a map of bitmasks

--- a/test/Tests/ConfigTest.php
+++ b/test/Tests/ConfigTest.php
@@ -14,14 +14,14 @@ class ConfigTest extends \PHPUnit_Framework_TestCase {
         $this->assertInstanceOf('Zumba\Swivel\Bucket', $bucket);
     }
 
-    public function testSetBucket() {
+    public function testSetBucketIndex() {
         $config = new Config();
         $image = new \ReflectionClass($config);
         $index = $image->getProperty('index');
         $index->setAccessible(true);
         $this->assertNull($index->getValue($config));
 
-        $config->setBucket(5);
+        $config->setBucketIndex(5);
         $this->assertEquals(5, $index->getValue($config));
     }
 

--- a/test/Tests/ConfigTest.php
+++ b/test/Tests/ConfigTest.php
@@ -2,7 +2,8 @@
 namespace Tests;
 
 use \Zumba\Swivel\Config,
-    \Zumba\Swivel\Bucket;
+    \Zumba\Swivel\Bucket,
+    \Zumba\Swivel\MapInterface;
 
 class ConfigTest extends \PHPUnit_Framework_TestCase {
 
@@ -22,5 +23,31 @@ class ConfigTest extends \PHPUnit_Framework_TestCase {
 
         $config->setBucket(5);
         $this->assertEquals(5, $index->getValue($config));
+    }
+
+    public function testAddMapInterface() {
+        $map = $this->getMock('Zumba\Swivel\MapInterface');
+        $map->expects($this->once())->method('setLogger');
+        $config = new Config($map);
+    }
+
+    public function testAddDriverInterface() {
+        $driver = $this->getMock('Zumba\Swivel\DriverInterface');
+        $map = $this->getMock('Zumba\Swivel\MapInterface');
+
+        $driver
+            ->expects($this->once())
+            ->method('getMap')
+            ->will($this->returnValue($map));
+
+        $map->expects($this->once())->method('setLogger');
+        $config = new Config($driver);
+    }
+
+    /**
+     * @expectedException \LogicException
+     */
+    public function testUnknownObject() {
+        $config = new Config(new \stdClass());
     }
 }

--- a/test/Tests/ConfigTest.php
+++ b/test/Tests/ConfigTest.php
@@ -5,55 +5,6 @@ use \Zumba\Swivel\Config,
     \Zumba\Swivel\Bucket;
 
 class ConfigTest extends \PHPUnit_Framework_TestCase {
-    public function testConstructorAddsEmptyMap() {
-        $config = new Config();
-        $this->assertEmpty($config->getFeatures());
-    }
-
-    public function testConstructorAddsMapParam() {
-        $map = ['Feature' => [1,2,3]];
-        $config = new Config($map);
-        $this->assertEquals($map, $config->getFeatures());
-    }
-
-    public function testAddFeature() {
-        $config = new Config();
-        $slug = 'Test';
-        $buckets = [1,2];
-        $config->addFeature($slug, $buckets);
-        $this->assertEquals($buckets, $config->getFeatures()[$slug]);
-    }
-
-    public function testAddFeatures() {
-        $config = new Config();
-        $features = [ 'A' => [1,2,3], 'B' => [4,5,6] ];
-        $config->addFeatures($features);
-        $this->assertEquals($features, $config->getFeatures());
-    }
-
-    public function testFeaturesAreCumulative() {
-        $config = new Config();
-        $features = [ 'A' => [1,2,3] ];
-        $config->addFeatures($features);
-        $config->addFeature('A', [9]);
-        $this->assertEquals([ 'A' => [1,2,3,9] ], $config->getFeatures());
-    }
-
-    public function testRemoveFeature() {
-        $config = new Config();
-        $features = [ 'A' => [1,2,3], 'B' => [4,5,6] ];
-        $config->addFeatures($features);
-        $config->removeFeature('B');
-        $this->assertEquals([ 'A' => [1,2,3] ], $config->getFeatures());
-    }
-
-    public function testRemoveFeatureBucketOnly() {
-        $config = new Config();
-        $features = [ 'A' => [1,2,3], 'B' => [4,5,6] ];
-        $config->addFeatures($features);
-        $config->removeFeature('B', [5]);
-        $this->assertEquals([ 'A' => [1,2,3], 'B' => [4,6] ], $config->getFeatures());
-    }
 
     public function testGetBucket() {
         $index = 4;

--- a/test/Tests/MapTest.php
+++ b/test/Tests/MapTest.php
@@ -14,6 +14,50 @@ class MapTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals($expected, $featureMap->parse($map));
     }
 
+    /**
+     * @dataProvider enabledProvider
+     */
+    public function testEnabled($assertion, $slug, $index, $map) {
+        $featureMap = new Map($map);
+        $this->$assertion($featureMap->enabled($slug, $index));
+    }
+
+    /**
+     * @dataProvider diffProvider
+     */
+    public function testDiff($a, $b, $expected) {
+        $map1 = new Map($a);
+        $map2 = new Map($b);
+        $this->assertEquals($expected, $map1->diff($map2)->getMapData());
+    }
+
+    /**
+     * @dataProvider mergeProvider
+     */
+    public function testMerge($a, $b, $expected) {
+        $map1 = new Map($a);
+        $map2 = new Map($b);
+        $this->assertEquals($expected, $map1->merge($map2)->getMapData());
+    }
+
+    /**
+     * @dataProvider intersectProvider
+     */
+    public function testIntersect($a, $b, $expected) {
+        $map1 = new Map($a);
+        $map2 = new Map($b);
+        $this->assertEquals($expected, $map1->intersect($map2)->getMapData());
+    }
+
+    /**
+     * @dataProvider addProvider
+     */
+    public function testAdd($a, $b, $expected) {
+        $map1 = new Map($a);
+        $map2 = new Map($b);
+        $this->assertEquals($expected, $map1->add($map2)->getMapData());
+    }
+
     public function parseProvider() {
         return [
             [
@@ -27,16 +71,12 @@ class MapTest extends \PHPUnit_Framework_TestCase {
             [
                 [ 'a' => [6, 7], 'a.b' => [7] ],
                 [ 'a' => Bucket::SIXTH | Bucket::SEVENTH, 'a.b' => Bucket::SEVENTH ]
+            ],
+            [
+                [ 'a' => Bucket::FIRST ],
+                [ 'a' => Bucket::FIRST ]
             ]
         ];
-    }
-
-    /**
-     * @dataProvider enabledProvider
-     */
-    public function testEnabled($assertion, $slug, $index, $map) {
-        $featureMap = new Map($map);
-        $this->$assertion($featureMap->enabled($slug, $index));
     }
 
     public function enabledProvider() {
@@ -97,6 +137,138 @@ class MapTest extends \PHPUnit_Framework_TestCase {
                     'Test.version.a' => [3]
                 ]
             ],
+        ];
+    }
+
+    public function diffProvider() {
+        return [
+            [
+                [ 'a' => [1,2,3], 'b' => [4,5,6] ],
+                [ 'a' => [1,2,3], 'b' => [4,5,6] ],
+                []
+            ],
+            [
+                [ 'a' => [1,2], 'b' => [4,5,6] ],
+                [ 'a' => [1,2,3], 'b' => [4,5,6] ],
+                [ 'a' => Bucket::FIRST | Bucket::SECOND | Bucket::THIRD ]
+            ],
+            [
+                [ 'a' => [1,2,3], 'b' => [4,5,6], 'c' => [7] ],
+                [ 'a' => [1,2,3], 'b' => [4,5,6] ],
+                [ 'c' => Bucket::SEVENTH ]
+            ],
+            [
+                [ 'a' => [1,2,3], 'b' => [4,5,6] ],
+                [ 'a' => [1,2,3], 'b' => [4,5,6], 'd' => [1] ],
+                [ 'd' => Bucket::FIRST ]
+            ],
+            [
+                [ 'a' => [1,2,3], 'b' => [4,5,6], 'c' => [7] ],
+                [ 'a' => [1,2,3], 'b' => [4,5,6], 'd' => [1] ],
+                [ 'd' => Bucket::FIRST, 'c' => Bucket::SEVENTH ]
+            ],
+            [
+                [ 'a' => [1,2,3], 'b' => [4,5,6] ],
+                [ 'a' => [], 'b' => [] ],
+                [ 'a' => 0, 'b' => 0 ]
+            ]
+        ];
+    }
+
+    public function intersectProvider() {
+        return [
+            [
+                [ 'a' => [1,2,3], 'b' => [4,5,6] ],
+                [ 'a' => [1,2,3], 'b' => [4,5,6] ],
+                [
+                    'a' => Bucket::FIRST | Bucket::SECOND | Bucket::THIRD,
+                    'b' => Bucket::FOURTH | Bucket::FIFTH | Bucket::SIXTH
+                ]
+            ],
+            [
+                [ 'a' => [1,2], 'b' => [4,5,6] ],
+                [ 'a' => [1,2,3], 'b' => [4,5,6] ],
+                [ 'b' => Bucket::FOURTH | Bucket::FIFTH | Bucket::SIXTH ]
+            ],
+            [
+                [ 'a' => [1,2,3], 'b' => [4,5,6], 'c' => [7] ],
+                [ 'a' => [2,3,4], 'b' => [4,5,6] ],
+                [ 'b' => Bucket::FOURTH | Bucket::FIFTH | Bucket::SIXTH ]
+            ],
+            [
+                [ 'a' => [1,2,3], 'b' => [4,5,6] ],
+                [ 'a' => [1,2,3], 'b' => [9,8,7], 'd' => [1] ],
+                [ 'a' => Bucket::FIRST | Bucket::SECOND | Bucket::THIRD ]
+            ]
+        ];
+    }
+
+    public function mergeProvider() {
+        return [
+            [
+                [ 'a' => [1,2,3], 'b' => [4,5,6] ],
+                [ 'a' => [1,2,3], 'b' => [4,5,6] ],
+                [
+                    'a' => Bucket::FIRST | Bucket::SECOND | Bucket::THIRD,
+                    'b' => Bucket::FOURTH | Bucket::FIFTH | Bucket::SIXTH
+                ]
+            ],
+            [
+                [ 'a' => [1,2], 'b' => [4,5,6] ],
+                [ 'a' => [1,2,3], 'b' => [4,5,6] ],
+                [
+                    'a' => Bucket::FIRST | Bucket::SECOND | Bucket::THIRD,
+                    'b' => Bucket::FOURTH | Bucket::FIFTH | Bucket::SIXTH
+                ]
+            ],
+            [
+                [ 'a' => [1,2,3], 'b' => [4,5,6], 'c' => [7] ],
+                [ 'a' => [2,3,4], 'b' => [4,5,6] ],
+                [
+                    'a' => Bucket::SECOND | Bucket::THIRD | Bucket::FOURTH,
+                    'b' => Bucket::FOURTH | Bucket::FIFTH | Bucket::SIXTH,
+                    'c' => Bucket::SEVENTH
+                ]
+            ],
+            [
+                [ 'a' => [1,2,3], 'b' => [4,5,6] ],
+                [ 'a' => [1,2,3], 'b' => [9,8,7], 'd' => [1] ],
+                [
+                    'a' => Bucket::FIRST | Bucket::SECOND | Bucket::THIRD,
+                    'b' => Bucket::NINTH | Bucket::EIGHTH | Bucket::SEVENTH,
+                    'd' => Bucket::FIRST
+                ]
+            ]
+        ];
+    }
+
+    public function addProvider() {
+        return [
+            [
+                [ 'a' => [1,2,3], 'b' => [4,5,6] ],
+                [ 'a' => [1,2,3], 'b' => [4,5,6] ],
+                [
+                    'a' => Bucket::FIRST | Bucket::SECOND | Bucket::THIRD,
+                    'b' => Bucket::FOURTH | Bucket::FIFTH | Bucket::SIXTH
+                ]
+            ],
+            [
+                [ 'a' => [1,2,3], 'b' => [4,5,6] ],
+                [ 'a' => [3,4,5], 'b' => [4,5,6] ],
+                [
+                    'a' => Bucket::FIRST | Bucket::SECOND | Bucket::THIRD | Bucket::FOURTH | Bucket::FIFTH,
+                    'b' => Bucket::FOURTH | Bucket::FIFTH | Bucket::SIXTH
+                ]
+            ],
+            [
+                [ 'a' => [1,2,3], 'b' => [4,5,6], 'c' => [7] ],
+                [ 'a' => [2,3,4], 'b' => [4,5,6] ],
+                [
+                    'a' => Bucket::FIRST | Bucket::SECOND | Bucket::THIRD | Bucket::FOURTH,
+                    'b' => Bucket::FOURTH | Bucket::FIFTH | Bucket::SIXTH,
+                    'c' => Bucket::SEVENTH
+                ]
+            ]
         ];
     }
 }


### PR DESCRIPTION
This PR includes:
- A new DriverInterface
- Config now accepts an array, a `MapInterface` or a `DriverInterface`.  Config will throw a `LogicException` if it encounters something else.
- New manipulation functions on `Map`:  `Map::diff`, `Map::intersect`, `Map::merge`, and `Map::add`.
- Map now takes an optional logger in the constructor.
- Adding and subtracting features has been removed from the `Config` object.  They can be added to the `Map` object if they are deemed necessary.
