### PR TITLE
Allow falsey, non-callable values in shorthand

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -11,6 +11,7 @@ class Builder implements BuilderInterface {
     use \Psr\Log\LoggerAwareTrait;
 
     const DEFAULT_SLUG = '__swivel_default';
+    const DEFAULT_STRATEGY = '__swivel_default_strategy';
 
     /**
      * Arguments to be passed to the behavior
@@ -140,9 +141,9 @@ class Builder implements BuilderInterface {
      * @param mixed $strategy
      * @return \Zumba\Swivel\BehaviorInterface
      */
-    public function getBehavior($slug, $strategy = null) {
+    public function getBehavior($slug, $strategy = self::DEFAULT_STRATEGY) {
         $this->logger->debug('Swivel - Creating new behavior.', compact('slug'));
-        if (empty($strategy)) {
+        if ($strategy === static::DEFAULT_STRATEGY) {
             $strategy = $slug;
             $slug = static::DEFAULT_SLUG;
         }

--- a/test/Tests/Integration/SwivelTest.php
+++ b/test/Tests/Integration/SwivelTest.php
@@ -172,6 +172,14 @@ class SwivelTest extends \PHPUnit_Framework_TestCase {
         $this->assertSame(null, $result);
     }
 
+    /**
+     * @dataProvider falseyValueProvider
+     */
+    public function testShorthandFalseyValuesAllowed($falseyValue) {
+        $swivel = new Manager(new Config($this->map, 10));
+        $this->assertSame($falseyValue, $swivel->invoke('OldFeature.Legacy', $falseyValue));
+    }
+
     public function allBucketProvider() {
         return [ [1], [2], [3], [4], [5], [6], [7], [8], [9], [10] ];
     }
@@ -182,5 +190,9 @@ class SwivelTest extends \PHPUnit_Framework_TestCase {
             [ 7, 'assertFalse', 'assertTrue', 'assertFalse', 'assertTrue' ],
             [ 8, 'assertTrue', 'assertFalse', 'assertFalse', 'assertFalse' ]
         ];
+    }
+
+    public function falseyValueProvider() {
+        return [ [0], [[]], [null], [''], [false] ];
     }
 }


### PR DESCRIPTION
This fixes a bug when relying on the shorthand feature of `addBehavior` that produced invalid results when passing in falsey values.
