### PR TITLE
Split public api

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,8 +307,7 @@ Lazily adds a behavior to this feature that will return the provided value.  It 
 
 Param                      | Type       | Details
 :--------------------------|:-----------|:--------
-**$strategy**              | *callable* | The strategy to execute if no other feature behaviors are enabled for the user's bucket. Since version 2.0.0 `$strategy` must be a callable.  If you want to return a simple value, use `Builder::defaultValue` instead.
-**$args**<br/>*(optional)* | *array*    | Parameters to pass to the `$strategy` callable if it is executed.
+**$value**              | *mixed* | The value to return if no other feature behaviors are enabled for the user's bucket. If you want ***Swivel*** to execute a callable, use `Builder::defaultBehavior` instead.
 
 ##### Examples
 

--- a/README.md
+++ b/README.md
@@ -116,11 +116,11 @@ public function search($params = []) {
         ->execute();
 }
 
-public function normalSearch($params) {
+protected function normalSearch($params) {
     // Tried and True method.
 }
 
-public function awesomeSearch($params) {
+protected function awesomeSearch($params) {
     // Super cool new search method.
 }
 ```
@@ -210,6 +210,27 @@ $result = $swivel->invoke('Search.New', [$this, 'search'], [$this, 'noOp']);
 $result = $swivel->invoke('Search.New', [$this, 'search']);
 ```
 
+#### returnValue($slug, $a, $b)
+
+Shorthand syntactic sugar for invoking a simple feature behavior using `Builder::addValue`.  Useful for ternary style code.
+
+Param                   | Type     | Details
+:-----------------------|:---------|:--------
+**$slug**               | *string* | The first section of a feature map slug.  i.e., for the feature slug `"Test.Version.Two"`, the `$slug` would be `"Test"`
+**$a**                  | *mixed*  | The value to return if the `$slug` is enabled for the user's bucket.
+**$b**<br/>*(optional)* | *mixed*  | The value to return if the `$slug` is not enabled for the user's bucket.  If omitted, `returnValue` will return `null` if the feature slug is not enabled.
+
+##### Examples
+
+```php
+// without Swivel
+$result = $newSearch ? 'Everything' : null;
+
+// Zumba\Swivel\Manager::returnValue
+$result = $swivel->returnValue('Search.New', 'Everything', null);
+$result = $swivel->returnValue('Search.New', 'Everything');
+```
+
 ### Zumba\Swivel\Builder
 
 The `Builder` API is the primary way that you will write ***Swivel*** code.  You get a new instance of the `Builder` when you call `Manager::forFeature`.
@@ -218,11 +239,11 @@ The `Builder` API is the primary way that you will write ***Swivel*** code.  You
 
 Lazily adds a behavior to this feature that will only be executed if the feature is enabled for the user's bucket.
 
-Param                      | Type     | Details
-:--------------------------|:---------|:--------
-**$slug**                  | *string* | The second section of a feature map slug.  i.e., for the feature slug `"Test.Version.Two"`, the `$slug` here would be `"Version.Two"`
-**$strategy**              | *mixed*  | The strategy to execute if the `$slug` is enabled for the user's bucket. If `$strategy` is not a callable it will be wrapped in an anonymous function for you and treated as the evaluated result.
-**$args**<br/>*(optional)* | *array*  | Parameters to pass to the `$strategy` callable if it is executed.
+Param                      | Type        | Details
+:--------------------------|:------------|:--------
+**$slug**                  | *string*    | The second section of a feature map slug.  i.e., for the feature slug `"Test.Version.Two"`, the `$slug` here would be `"Version.Two"`
+**$strategy**              | *callable*  | The strategy to execute if the `$slug` is enabled for the user's bucket. Since version 2.0.0 `$strategy` must be a callable.  If you want to return a simple value, use `Builder::addValue` instead.
+**$args**<br/>*(optional)* | *array*     | Parameters to pass to the `$strategy` callable if it is executed.
 
 ##### Examples
 
@@ -236,18 +257,40 @@ $builder
     // Callable.  Will return the result of $obj->someMethod('c', 'd');
     ->addBehavior('versionB', [$obj, 'someMethod'], ['c', 'd'])
 
-     // Literal. Will return 'result' if executed
+     // Since version 2.0.0, this will throw a \LogicException.  Use `addValue` instead.
     ->addBehavior('versionC', 'result');
+```
+
+#### addValue($slug, $value)
+
+Lazily adds a behavior to this feature that will return the value provided.  It will only be executed if the feature is enabled for the user's bucket.
+
+Param                      | Type     | Details
+:--------------------------|:---------|:--------
+**$slug**                  | *string* | The second section of a feature map slug.  i.e., for the feature slug `"Test.Version.Two"`, the `$slug` here would be `"Version.Two"`
+**$value**                 | *mixed*  | The value to return if the `$slug` is enabled for the user's bucket. If `$value` is a callable it will not be executed.  If you want ***Swivel*** to execute a callable, use `Builder::addBehavior` instead.
+
+##### Examples
+
+```php
+$builder = $swivel->forFeature('Test');
+
+$builder
+    // This will return `'result'`
+    ->addValue('versionA', 'result')
+
+    // Callable.  This will not be executed; Swivel will just return the unexecuted callable.
+    ->addValue('versionB', [$obj, 'someMethod']);
 ```
 
 #### defaultBehavior($strategy, $args)
 
 Lazily adds a behavior to this feature that will only be executed if no other feature behaviors are enabled for the user's bucket.
 
-Param                      | Type    | Details
-:--------------------------|:--------|:--------
-**$strategy**              | *mixed* | The strategy to execute if no other feature behaviors are enabled for the user's bucket. If `$strategy` is not a callable it will be wrapped in an anonymous function for you and treated as the evaluated result.
-**$args**<br/>*(optional)* | *array* | Parameters to pass to the `$strategy` callable if it is executed.
+Param                      | Type       | Details
+:--------------------------|:-----------|:--------
+**$strategy**              | *callable* | The strategy to execute if no other feature behaviors are enabled for the user's bucket. Since version 2.0.0 `$strategy` must be a callable.  If you want to return a simple value, use `Builder::defaultValue` instead.
+**$args**<br/>*(optional)* | *array*    | Parameters to pass to the `$strategy` callable if it is executed.
 
 ##### Examples
 
@@ -256,6 +299,24 @@ $swivel
     ->forFeature('Test');
     ->addBehavior('New.Version', [$this, 'someMethod'], $args)
     ->defaultBehavior([$this, 'defaultMethod'], $args);
+```
+
+#### defaultValue($value)
+
+Lazily adds a behavior to this feature that will return the provided value.  It will only be executed if no other feature behaviors are enabled for the user's bucket.
+
+Param                      | Type       | Details
+:--------------------------|:-----------|:--------
+**$strategy**              | *callable* | The strategy to execute if no other feature behaviors are enabled for the user's bucket. Since version 2.0.0 `$strategy` must be a callable.  If you want to return a simple value, use `Builder::defaultValue` instead.
+**$args**<br/>*(optional)* | *array*    | Parameters to pass to the `$strategy` callable if it is executed.
+
+##### Examples
+
+```php
+$swivel
+    ->forFeature('Test');
+    ->addBehavior('New.Version', [$this, 'someMethod'], $args)
+    ->defaultValue('some default value');
 ```
 
 #### execute()

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -145,7 +145,7 @@ class Builder implements BuilderInterface {
      */
     public function defaultValue($value) {
         if ($this->defaultWaived) {
-            $exception = new \LogicException('Defined a default alue after `noDefault` was called.');
+            $exception = new \LogicException('Defined a default value after `noDefault` was called.');
             $this->logger->critical('Swivel', compact('exception'));
             throw $exception;
         }

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -96,6 +96,25 @@ class Builder implements BuilderInterface {
     }
 
     /**
+     * Add a value to be returned when the builder is executed.
+     *
+     * Value will only be returned if it is enabled for the user's bucket.
+     *
+     * @param string $slug
+     * @param mixed $value
+     * @return \Zumba\Swivel\BuilderInterface
+     */
+    public function addValue($slug, $value) {
+        $behavior = $this->getBehavior($slug, function() use ($value) {
+            return $value;
+        });
+        if ($this->bucket->enabled($behavior)) {
+            $this->setBehavior($behavior);
+        }
+        return $this;
+    }
+
+    /**
      * Add a default behavior.
      *
      * Will be used if all other behaviors are not enabled for the user's bucket.

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -117,9 +117,9 @@ class Builder implements BuilderInterface {
     /**
      * Add a default behavior.
      *
-     * Will be used if all other behaviors are not enabled for the user's bucket.
+     * Will be used if all other behaviors and values are not enabled for the user's bucket.
      *
-     * @param mixed $strategy
+     * @param callable $strategy
      * @param array $args
      * @return \Zumba\Swivel\BuilderInterface
      */
@@ -131,6 +131,27 @@ class Builder implements BuilderInterface {
         }
         if (!$this->behavior) {
             $this->setBehavior($this->getBehavior($strategy), $args);
+        }
+        return $this;
+    }
+
+    /**
+     * Add a default value.
+     *
+     * Will be used if all other behaviors and values are not enabled for the user's bucket.
+     *
+     * @param mixed $value
+     * @return \Zumba\Swivel\BuilderInterface
+     */
+    public function defaultValue($value) {
+        if ($this->defaultWaived) {
+            $exception = new \LogicException('Defined a default alue after `noDefault` was called.');
+            $this->logger->critical('Swivel', compact('exception'));
+            throw $exception;
+        }
+        if (!$this->behavior) {
+            $callable = function() use ($value) { return $value; };
+            $this->setBehavior($this->getBehavior($callable));
         }
         return $this;
     }

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -162,7 +162,7 @@ class Builder implements BuilderInterface {
      * @return mixed
      */
     public function execute() {
-        $behavior = $this->behavior ?: $this->getBehavior(null);
+        $behavior = $this->behavior ?: $this->getBehavior(function() { return null; });
         $behaviorSlug = $behavior->getSlug();
 
         $this->metrics && $this->startMetrics($behaviorSlug);

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -56,9 +56,11 @@ class Manager implements ManagerInterface {
     /**
      * Syntactic sugar for creating simple feature toggles (ternary style)
      *
+     * Uses Builder::addBehavior
+     *
      * @param string $slug
-     * @param mixed $a
-     * @param mixed $b
+     * @param callable $a
+     * @param callable $b
      * @return mixed
      * @see \Zumba\Swivel\ManagerInterface
      */
@@ -67,7 +69,27 @@ class Manager implements ManagerInterface {
         $feature = array_shift($parts);
         return $this->forFeature($feature)
             ->addBehavior(implode(Map::DELIMITER, $parts), $a)
-            ->defaultBehavior($b)
+            ->defaultBehavior($b ? $b : function () use ($b) { return $b; })
+            ->execute();
+    }
+
+    /**
+     * Syntactic sugar for creating simple feature toggles (ternary style)
+     *
+     * Uses Builder::addValue
+     *
+     * @param string $slug
+     * @param mixed $a
+     * @param mixed $b
+     * @return mixed
+     * @see \Zumba\Swivel\ManagerInterface
+     */
+    public function returnValue($slug, $a, $b = null) {
+        $parts = explode(Map::DELIMITER, $slug);
+        $feature = array_shift($parts);
+        return $this->forFeature($feature)
+            ->addValue(implode(Map::DELIMITER, $parts), $a)
+            ->defaultValue($b)
             ->execute();
     }
 

--- a/test/Tests/BuilderTest.php
+++ b/test/Tests/BuilderTest.php
@@ -117,7 +117,7 @@ class BuilderTest extends \PHPUnit_Framework_TestCase {
         $builder = $this->getMock('Zumba\Swivel\Builder', null, ['Test', $bucket]);
         $builder->setMetrics($this->getMock('Zumba\Swivel\MetricsInterface'));
         $builder->setLogger(new NullLogger());
-        $builder->defaultBehavior('abc');
+        $builder->defaultBehavior(function() { return 'abc'; });
         $this->assertSame('abc', $builder->execute());
     }
 

--- a/test/Tests/BuilderTest.php
+++ b/test/Tests/BuilderTest.php
@@ -7,6 +7,51 @@ use \Psr\Log\NullLogger;
 use \Zumba\Swivel\MetricsInterface;
 
 class BuilderTest extends \PHPUnit_Framework_TestCase {
+
+    /**
+     * Used for testing that protected method is called with proper arguments
+     *
+     * @param string $arg1
+     * @param string $arg2
+     * @return string Args concatenated together
+     */
+    protected function protectedMethod($arg1, $arg2) {
+        return $arg1 . $arg2;
+    }
+
+    /**
+     * Used for testing that private method is called with proper arguments
+     *
+     * @param string $arg1
+     * @param string $arg2
+     * @return string Args concatenated together
+     */
+    private function privateMethod($arg1, $arg2) {
+        return $arg1 . $arg2;
+    }
+
+    /**
+     * Used for testing that protected static method is called with proper arguments
+     *
+     * @param string $arg1
+     * @param string $arg2
+     * @return string Args concatenated together
+     */
+    protected static function protectedStaticMethod($arg1, $arg2) {
+        return $arg1 . $arg2;
+    }
+
+    /**
+     * Used for testing that private static method is called with proper arguments
+     *
+     * @param string $arg1
+     * @param string $arg2
+     * @return string Args concatenated together
+     */
+    private static function privateStaticMethod($arg1, $arg2) {
+        return $arg1 . $arg2;
+    }
+
     public function testAddBehaviorNotEnabled() {
         $map = $this->getMock('Zumba\Swivel\Map');
         $bucket = $this->getMock('Zumba\Swivel\Bucket', ['enabled'], [$map]);
@@ -196,49 +241,5 @@ class BuilderTest extends \PHPUnit_Framework_TestCase {
 
         $this->assertEquals('ArgaArgb', $behavior->execute(['Arga', 'Argb']),
             'Test that the private static method is able to be called');
-    }
-
-    /**
-     * Used for testing that protected method is called with proper arguments
-     * 
-     * @param string $arg1
-     * @param string $arg2
-     * @return string Args concatenated together
-     */
-    protected function protectedMethod($arg1, $arg2) {
-        return $arg1.$arg2;
-    }
-
-    /**
-     * Used for testing that private method is called with proper arguments
-     * 
-     * @param string $arg1
-     * @param string $arg2
-     * @return string Args concatenated together
-     */
-    private function privateMethod($arg1, $arg2) {
-        return $arg1.$arg2;
-    }
-
-    /**
-     * Used for testing that protected static method is called with proper arguments
-     * 
-     * @param string $arg1
-     * @param string $arg2
-     * @return string Args concatenated together
-     */
-    protected static function protectedStaticMethod($arg1, $arg2) {
-        return $arg1.$arg2;
-    }
-
-    /**
-     * Used for testing that private static method is called with proper arguments
-     * 
-     * @param string $arg1
-     * @param string $arg2
-     * @return string Args concatenated together
-     */
-    private static function privateStaticMethod($arg1, $arg2) {
-        return $arg1.$arg2;
     }
 }

--- a/test/Tests/Integration/SwivelTest.php
+++ b/test/Tests/Integration/SwivelTest.php
@@ -183,11 +183,19 @@ class SwivelTest extends \PHPUnit_Framework_TestCase {
     /**
      * @dataProvider falseyValueProvider
      */
-    public function testShorthandFalseyValuesAllowed($falseyValue) {
+    public function testFalseyValuesAllowedInBehaviors($falseyValue) {
         $swivel = new Manager(new Config($this->map, 10));
         $this->assertSame($falseyValue, $swivel->invoke('OldFeature.Legacy', function() use ($falseyValue) {
             return $falseyValue;
         }));
+    }
+
+    /**
+     * @dataProvider falseyValueProvider
+     */
+    public function testFalseyValuesAllowed($falseyValue) {
+        $swivel = new Manager(new Config($this->map, 10));
+        $this->assertSame($falseyValue, $swivel->returnValue('OldFeature.Legacy', $falseyValue));
     }
 
     public function allBucketProvider() {

--- a/test/Tests/ManagerTest.php
+++ b/test/Tests/ManagerTest.php
@@ -41,13 +41,13 @@ class ManagerTest extends \PHPUnit_Framework_TestCase {
         $builder
             ->expects($this->once())
             ->method('addBehavior')
-            ->with('version.a', 'abc')
+            ->with('version.a', $this->isType('callable'))
             ->will($this->returnValue($builder));
 
         $builder
             ->expects($this->once())
             ->method('defaultBehavior')
-            ->with(null)
+            ->with($this->isType('callable'))
             ->will($this->returnValue($builder));
 
         $builder
@@ -55,7 +55,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase {
             ->method('execute')
             ->will($this->returnValue('abc'));
 
-        $this->assertEquals('abc', $manager->invoke('Test.version.a', 'abc'));
+        $this->assertEquals('abc', $manager->invoke('Test.version.a', function() { return 'abc'; }));
     }
 
     public function testInvokeOneParamDisabled() {
@@ -75,20 +75,20 @@ class ManagerTest extends \PHPUnit_Framework_TestCase {
         $builder
             ->expects($this->once())
             ->method('addBehavior')
-            ->with('version.a', 'abc')
+            ->with('version.a', $this->isType('callable'))
             ->will($this->returnValue($builder));
 
         $builder
             ->expects($this->once())
             ->method('defaultBehavior')
-            ->with(null)
+            ->with($this->isType('callable'))
             ->will($this->returnValue($builder));
 
         $builder
             ->expects($this->once())
             ->method('execute');
 
-        $this->assertEquals(null, $manager->invoke('Test.version.a', 'abc'));
+        $this->assertEquals(null, $manager->invoke('Test.version.a', function() { return 'abc'; }));
     }
 
     public function testInvokeTwoParamEnabled() {

--- a/test/Tests/ManagerTest.php
+++ b/test/Tests/ManagerTest.php
@@ -108,13 +108,13 @@ class ManagerTest extends \PHPUnit_Framework_TestCase {
         $builder
             ->expects($this->once())
             ->method('addBehavior')
-            ->with('version.a', 'abc')
+            ->with('version.a', $this->isType('callable'))
             ->will($this->returnValue($builder));
 
         $builder
             ->expects($this->once())
             ->method('defaultBehavior')
-            ->with('default')
+            ->with($this->isType('callable'))
             ->will($this->returnValue($builder));
 
         $builder
@@ -122,7 +122,11 @@ class ManagerTest extends \PHPUnit_Framework_TestCase {
             ->method('execute')
             ->will($this->returnValue('abc'));
 
-        $this->assertEquals('abc', $manager->invoke('Test.version.a', 'abc', 'default'));
+        $this->assertEquals('abc', $manager->invoke(
+            'Test.version.a',
+            function() { return 'abc'; },
+            function() { return 'default'; }
+        ));
     }
 
     public function testInvokeTwoParamDisabled() {
@@ -142,13 +146,13 @@ class ManagerTest extends \PHPUnit_Framework_TestCase {
         $builder
             ->expects($this->once())
             ->method('addBehavior')
-            ->with('version.a', 'abc')
+            ->with('version.a', $this->isType('callable'))
             ->will($this->returnValue($builder));
 
         $builder
             ->expects($this->once())
             ->method('defaultBehavior')
-            ->with('default')
+            ->with($this->isType('callable'))
             ->will($this->returnValue($builder));
 
         $builder
@@ -156,7 +160,11 @@ class ManagerTest extends \PHPUnit_Framework_TestCase {
             ->method('execute')
             ->will($this->returnValue('default'));
 
-        $this->assertEquals('default', $manager->invoke('Test.version.a', 'abc', 'default'));
+        $this->assertEquals('default', $manager->invoke(
+            'Test.version.a',
+            function() { return 'abc'; },
+            function() { return 'default'; }
+        ));
     }
 
     public function testSetMetrics() {
@@ -173,5 +181,140 @@ class ManagerTest extends \PHPUnit_Framework_TestCase {
         $metrics = $image->getProperty('metrics');
         $metrics->setAccessible(true);
         $this->assertSame($metricsInstance, $metrics->getValue($manager));
+    }
+
+    public function testReturnValueOneParamEnabled() {
+        $config = new Config();
+        $manager = $this->getMock('Zumba\Swivel\Manager', ['forFeature'], [$config]);
+        $builder = $this
+            ->getMockBuilder('Zumba\Swivel\Builder')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $manager
+            ->expects($this->once())
+            ->method('forFeature')
+            ->with('Test')
+            ->will($this->returnValue($builder));
+
+        $builder
+            ->expects($this->once())
+            ->method('addValue')
+            ->with('version.a', 'abc')
+            ->will($this->returnValue($builder));
+
+        $builder
+            ->expects($this->once())
+            ->method('defaultValue')
+            ->with(null)
+            ->will($this->returnValue($builder));
+
+        $builder
+            ->expects($this->once())
+            ->method('execute')
+            ->will($this->returnValue('abc'));
+
+        $this->assertEquals('abc', $manager->returnValue('Test.version.a', 'abc'));
+    }
+
+    public function testReturnValueOneParamDisabled() {
+        $config = new Config();
+        $manager = $this->getMock('Zumba\Swivel\Manager', ['forFeature'], [$config]);
+        $builder = $this
+            ->getMockBuilder('Zumba\Swivel\Builder')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $manager
+            ->expects($this->once())
+            ->method('forFeature')
+            ->with('Test')
+            ->will($this->returnValue($builder));
+
+        $builder
+            ->expects($this->once())
+            ->method('addValue')
+            ->with('version.a', 'abc')
+            ->will($this->returnValue($builder));
+
+        $builder
+            ->expects($this->once())
+            ->method('defaultValue')
+            ->with(null)
+            ->will($this->returnValue($builder));
+
+        $builder
+            ->expects($this->once())
+            ->method('execute');
+
+        $this->assertEquals(null, $manager->returnValue('Test.version.a', 'abc'));
+    }
+
+    public function testReturnValueTwoParamEnabled() {
+        $config = new Config();
+        $manager = $this->getMock('Zumba\Swivel\Manager', ['forFeature'], [$config]);
+        $builder = $this
+            ->getMockBuilder('Zumba\Swivel\Builder')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $manager
+            ->expects($this->once())
+            ->method('forFeature')
+            ->with('Test')
+            ->will($this->returnValue($builder));
+
+        $builder
+            ->expects($this->once())
+            ->method('addValue')
+            ->with('version.a', 'abc')
+            ->will($this->returnValue($builder));
+
+        $builder
+            ->expects($this->once())
+            ->method('defaultValue')
+            ->with('default')
+            ->will($this->returnValue($builder));
+
+        $builder
+            ->expects($this->once())
+            ->method('execute')
+            ->will($this->returnValue('abc'));
+
+        $this->assertEquals('abc', $manager->returnValue('Test.version.a', 'abc', 'default'));
+    }
+
+    public function testReturnValueTwoParamDisabled() {
+        $config = new Config();
+        $manager = $this->getMock('Zumba\Swivel\Manager', ['forFeature'], [$config]);
+        $builder = $this
+            ->getMockBuilder('Zumba\Swivel\Builder')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $manager
+            ->expects($this->once())
+            ->method('forFeature')
+            ->with('Test')
+            ->will($this->returnValue($builder));
+
+        $builder
+            ->expects($this->once())
+            ->method('addValue')
+            ->with('version.a', 'abc')
+            ->will($this->returnValue($builder));
+
+        $builder
+            ->expects($this->once())
+            ->method('defaultValue')
+            ->with('default')
+            ->will($this->returnValue($builder));
+
+        $builder
+            ->expects($this->once())
+            ->method('execute')
+            ->will($this->returnValue('default'));
+
+        $this->assertEquals('default', $manager->returnValue('Test.version.a', 'abc', 'default'));
     }
 }


### PR DESCRIPTION
This contains breaking changes that will lead to Swivel v2.0.0 after it is merged.

This PR simplifies the ambiguity surrounding `Builder::addBehavior` and `Manager::invoke` when automatically wrapping non-callables.
### Breaking Changes

`Builder::addBehavior`, `Builder::defaultBehavior`, and `Manager::invoke` no longer accept non-callable `$strategy` parameter.  These methods will throw a `\LogicException` when a non-callable is passed.
### New API

Three new methods have been introduced to handle the functionality that was removed in the breaking changes:
- `Builder::addValue`
- `Builder::defaultValue`
- `Manager::returnValue`

These methods are used to configure **_Swivel**_ to return a value that is not expected to be callable.  In the case of passing a callable to these methods, the unexecuted callable will be returned.
