### PR TITLE
php7.1: fix non-numeric value encountered warning

### DIFF
--- a/src/Map.php
+++ b/src/Map.php
@@ -127,7 +127,7 @@ class Map implements MapInterface {
             $key = empty($key) ? $child : $key.static::DELIMITER.$child;
 
             $isMissing = !$this->slugExists($key);
-            $isDisabled = $isMissing ?: !($map[$key] & $index);
+            $isDisabled = $isMissing ?: !((int)$map[$key] & $index);
 
             if ($isMissing || $isDisabled) {
                 $this->logger->debug('Swivel - "'.$slug.'" is not enabled for bucket '.$index);


### PR DESCRIPTION
Some swivels can return an empty string, and we can't perform bitwise & on
non-numeric values on 7.1 without getting a warning.

php 7.1 (adding cast eliminates the warning):
```
$ php --version
PHP 7.1.8-2+ubuntu16.04.1+deb.sury.org+4 (cli) (built: Aug  4 2017 13:04:12) ( NTS )
Copyright (c) 1997-2017 The PHP Group
Zend Engine v3.1.0, Copyright (c) 1998-2017 Zend Technologies
    with Zend OPcache v7.1.8-2+ubuntu16.04.1+deb.sury.org+4, Copyright (c) 1999-2017, by Zend Technologies

$ php -r 'var_dump("" & 0);'
PHP Warning:  A non-numeric value encountered in Command line code on line 1
int(0)
$ php -r 'var_dump((int)"" & 0);'
int(0)
```

php 5.6 (doesn't require the cast):
```
$ php --version
PHP 5.6.31-4+ubuntu16.04.1+deb.sury.org+4 (cli)
Copyright (c) 1997-2016 The PHP Group
Zend Engine v2.6.0, Copyright (c) 1998-2016 Zend Technologies
    with Zend OPcache v7.0.6-dev, Copyright (c) 1999-2016, by Zend Technologies

$ php -r 'var_dump("" & 0);'
int(0)
$ php -r 'var_dump((int)"" & 0);'
int(0)
```

Signed-off-by: Rene Fragoso <ctrlrsf@gmail.com>