### PR TITLE
PHP 7: Fix negative bitshift error when no buckets are enabled

### DIFF
--- a/src/Map.php
+++ b/src/Map.php
@@ -199,6 +199,9 @@ class Map implements MapInterface {
     protected function reduceToBitmask($list) {
         $this->logger->debug('Swivel - reducing to bitmask.', compact('list'));
         return !is_array($list) ? $list : array_reduce($list, function($mask, $index) {
+            if ((int)$index == 0) {
+                return $mask;
+            }
             return $mask | (1 << ($index - 1));
         });
     }

--- a/test/Tests/MapTest.php
+++ b/test/Tests/MapTest.php
@@ -100,6 +100,18 @@ class MapTest extends \PHPUnit_Framework_TestCase {
     public function parseProvider() {
         return [
             [
+                [ 'a' => [""] ],
+                [ 'a' => 0 ]
+            ],
+            [
+                [ 'a' => [0] ],
+                [ 'a' => 0 ]
+            ],
+            [
+                [ 'a' => [0, 1] ],
+                [ 'a' => Bucket::FIRST ]
+            ],
+            [
                 [ 'a' => [1] ],
                 [ 'a' => Bucket::FIRST ]
             ],
@@ -120,6 +132,13 @@ class MapTest extends \PHPUnit_Framework_TestCase {
 
     public function enabledProvider() {
         return [
+            [
+                'assertFalse', 'Test.version.a', 1, [
+                    'Test' => [],
+                    'Test.version' => [""],
+                    'Test.version.a' => [0]
+                ]
+            ],
             [
                 'assertTrue', 'Test.version.a', 1, [
                     'Test' => [1],


### PR DESCRIPTION
If a slug exists in the database but no buckets are enabled, we get back
an empty string. The empty string gets coreced into 0, then we subtact
1 to do the bitshift, and we end up with the negative bitshift error. In
php 5.x this is a silent error where the value ends up being
int(-9223372036854775808), but in php 7.1 it's a fatal error.

With this change when we reduce the array, if $index is 0 we just return
the $mask we have accumulated so far. There's no need to shift the 0
$index so we avoid it by returning early.

Closes: https://github.com/zumba/swivel/issues/33

Below are some examples of what reduceToBitmask was returning:

Before:
```
When Test.a swivel_features = 1,2,3,4,5,6,7,8,9,10
reduceToBitmask() returned int(1023)

When Test.a swivel_features = ""
reduceToBitmask() returned int(-9223372036854775808)
```

Now:
```
When Test.a swivel_features = 1,2,3,4,5,6,7,8,9,10
reduceToBitmask() returns int(1023)

When Test.a swivel_features = ""
reduceToBitmask() returns int(0)
```