### PR TITLE
Remove new interface methods.  These are backwards incompatable with …

### DIFF
--- a/src/BuilderInterface.php
+++ b/src/BuilderInterface.php
@@ -30,29 +30,6 @@ interface BuilderInterface extends \Psr\Log\LoggerAwareInterface
     public function defaultBehavior($strategy, array $args = []);
 
     /**
-     * Add a value to be returned when the builder is executed.
-     *
-     * Value will only be returned if it is enabled for the user's bucket.
-     *
-     * @param string $slug
-     * @param mixed  $value
-     *
-     * @return \Zumba\Swivel\BuilderInterface
-     */
-    public function addValue($slug, $value);
-
-    /**
-     * Add a default value.
-     *
-     * Will be used if all other behaviors and values are not enabled for the user's bucket.
-     *
-     * @param mixed $value
-     *
-     * @return \Zumba\Swivel\BuilderInterface
-     */
-    public function defaultValue($value);
-
-    /**
      * Creates a new Behavior object with an attached strategy.
      *
      * @param string $slug


### PR DESCRIPTION
…the previous patch version.

The new version 3.0.0 keeps these methods in the interface and is the new master.