### PR TITLE
Fixed issue where bitmask was resulting in NULL instead of 0

### DIFF
--- a/src/Map.php
+++ b/src/Map.php
@@ -226,7 +226,7 @@ class Map implements MapInterface
                 return $mask;
             }
             return $mask | (1 << ($index - 1));
-        });
+        }, 0);
     }
 
     /**


### PR DESCRIPTION
In case the mapping received an empty list of buckets or the value was 0 and it was the only value, the bitmask was returning NULL instead of the integer zero. The method is supposed to only return integer and it was breaking some checks down the line, such as comparing if a swivel exists in the map.