### PR TITLE
PHP 8.1 and 8.2 Test support and psr/log support up to ^3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['7.2', '7.3', '7.4', '8.0']
+        php-version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
 
     steps:
     - uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": ">=7.2",
-        "psr/log": "^1.0"
+        "psr/log": "^1.0 | ^2.0 | ^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5 || ^9.5",


### PR DESCRIPTION
Added PHP 8.1 and 8.2 to the actions testing matrix.
Added versions ^2.0 and ^3.0 to the list of allowed psr/log versions.