### PR TITLE
Dropped support to PHP 7.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php-version: ['8.0', '8.1', '8.2', '8.3']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
         }
     ],
     "require": {
-        "php": ">=7.2",
+        "php": "^8.0",
         "psr/log": "^1.0 | ^2.0 | ^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5 || ^9.5",
+        "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "^3.6"
     },
     "autoload": {

--- a/src/Behavior.php
+++ b/src/Behavior.php
@@ -13,7 +13,7 @@ class Behavior implements BehaviorInterface
      *
      * @var string
      */
-    protected $slug;
+    protected string $slug;
 
     /**
      * The strategy to be executed.
@@ -28,7 +28,7 @@ class Behavior implements BehaviorInterface
      * @param string   $slug
      * @param callable $strategy
      */
-    public function __construct($slug, callable $strategy)
+    public function __construct(string $slug, callable $strategy)
     {
         $this->slug = $slug;
         $this->strategy = $strategy;
@@ -43,14 +43,15 @@ class Behavior implements BehaviorInterface
      *
      * @see \Zumba\Swivel\BehaviorInterface
      */
-    public function execute(array $args = [])
+    public function execute(array $args = []): mixed
     {
         $slug = $this->slug;
         if ($this->logger) {
             $this->logger->debug('Swivel - Executing behavior.', compact('slug', 'args'));
         }
 
-        return call_user_func_array($this->strategy, $args);
+        $method = $this->strategy;
+        return $method(...$args);
     }
 
     /**
@@ -60,7 +61,7 @@ class Behavior implements BehaviorInterface
      *
      * @see \Zumba\Swivel\BehaviorInterface
      */
-    public function getSlug()
+    public function getSlug(): string
     {
         return $this->slug;
     }

--- a/src/BehaviorInterface.php
+++ b/src/BehaviorInterface.php
@@ -11,12 +11,12 @@ interface BehaviorInterface extends \Psr\Log\LoggerAwareInterface
      *
      * @return mixed
      */
-    public function execute(array $args = []);
+    public function execute(array $args = []): mixed;
 
     /**
      * Get the behavior's slug.
      *
      * @return string
      */
-    public function getSlug();
+    public function getSlug(): string;
 }

--- a/src/Bucket.php
+++ b/src/Bucket.php
@@ -2,7 +2,6 @@
 
 namespace Zumba\Swivel;
 
-use Zumba\Swivel\MapInterface;
 use Psr\Log\LoggerInterface;
 use Zumba\Swivel\Logging\NullLogger;
 
@@ -30,14 +29,14 @@ class Bucket implements BucketInterface
      *
      * @var Zumba\Swivel\MapInterface
      */
-    protected $featureMap;
+    protected MapInterface $featureMap;
 
     /**
      * The user's index.
      *
      * @var int Binary
      */
-    protected $index;
+    protected int $index;
 
     /**
      * Callback to handle a missing slug from Map
@@ -61,9 +60,8 @@ class Bucket implements BucketInterface
     ) {
         $this->setLogger($logger ?: new NullLogger());
         $this->featureMap = $featureMap;
-        $this->index = $index === null ? $this->randomIndex() : $index;
-        $this->callback = !is_null($callback) ? $callback : function () {
-        };
+        $this->index = $index ?: $this->randomIndex();
+        $this->callback = $callback ?: (fn() => null);
     }
 
     /**
@@ -75,12 +73,13 @@ class Bucket implements BucketInterface
      *
      * @see \Zumba\Swivel\BucketInterface
      */
-    public function enabled(BehaviorInterface $behavior)
+    public function enabled(BehaviorInterface $behavior): bool
     {
         $slug = $behavior->getSlug();
 
         if (!$this->featureMap->slugExists($slug)) {
-            call_user_func($this->callback, $slug);
+            $callback = $this->callback;
+            $callback($slug);
         }
         return $this->featureMap->enabled($slug, $this->index);
     }
@@ -92,7 +91,7 @@ class Bucket implements BucketInterface
      *
      * @return int
      */
-    public function getIndex()
+    public function getIndex(): int
     {
         return $this->index;
     }
@@ -102,7 +101,7 @@ class Bucket implements BucketInterface
      *
      * @return int
      */
-    protected function randomIndex()
+    protected function randomIndex(): int
     {
         return mt_rand(1, 10);
     }

--- a/src/BucketInterface.php
+++ b/src/BucketInterface.php
@@ -11,7 +11,7 @@ interface BucketInterface extends \Psr\Log\LoggerAwareInterface
      *
      * @return bool
      */
-    public function enabled(BehaviorInterface $behavior);
+    public function enabled(BehaviorInterface $behavior): bool;
 
     /**
      * Get the bucket index.
@@ -20,5 +20,5 @@ interface BucketInterface extends \Psr\Log\LoggerAwareInterface
      *
      * @return int
      */
-    public function getIndex();
+    public function getIndex(): int;
 }

--- a/src/BuilderInterface.php
+++ b/src/BuilderInterface.php
@@ -10,76 +10,45 @@ interface BuilderInterface extends \Psr\Log\LoggerAwareInterface
      * If $strategy is a callable it's return value will be returned when the behavior is executed;
      * if $strategy is not a callable, it will be directly returned by the behavior when it is
      * executed.
-     *
-     * @param string $slug
-     * @param mixed  $strategy
-     * @param array  $args
-     *
-     * @return \Zumba\Swivel\BuilderInterface
      */
-    public function addBehavior($slug, $strategy, array $args = []);
+    public function addBehavior(string $slug, mixed $strategy, array $args = []): BuilderInterface;
 
     /**
      * A fallback strategy if no added behaviors are active for the bucket.
-     *
-     * @param mixed $strategy
-     * @param array $args
-     *
-     * @return mixed
      */
-    public function defaultBehavior($strategy, array $args = []);
+    public function defaultBehavior(mixed $strategy, array $args = []): mixed;
 
     /**
      * Add a value to be returned when the builder is executed.
      *
      * Value will only be returned if it is enabled for the user's bucket.
-     *
-     * @param string $slug
-     * @param mixed  $value
-     *
-     * @return \Zumba\Swivel\BuilderInterface
      */
-    public function addValue($slug, $value);
+    public function addValue(string $slug, mixed $value): BuilderInterface;
 
     /**
      * Add a default value.
      *
      * Will be used if all other behaviors and values are not enabled for the user's bucket.
-     *
-     * @param mixed $value
-     *
-     * @return \Zumba\Swivel\BuilderInterface
      */
-    public function defaultValue($value);
+    public function defaultValue(mixed $value): BuilderInterface;
 
     /**
      * Creates a new Behavior object with an attached strategy.
-     *
-     * @param string $slug
-     * @param mixed  $strategy
-     *
-     * @return \Zumba\Swivel\Behavior
      */
-    public function getBehavior($slug, $strategy = null);
+    public function getBehavior(string|callable $slug, mixed $strategy = null): BehaviorInterface;
 
     /**
      * Indicates that the feature has no default behavior.
-     *
-     * @return \Zumba\Swivel\BuilderInterface
      */
-    public function noDefault();
+    public function noDefault(): BuilderInterface;
 
     /**
      * Execute the feature and return the result of the behavior.
-     *
-     * @return mixed
      */
-    public function execute();
+    public function execute(): mixed;
 
     /**
      * Set a metrics object.
-     *
-     * @param \Zumba\Swivel\MetricsInterface $metrics
      */
-    public function setMetrics(MetricsInterface $metrics);
+    public function setMetrics(MetricsInterface $metrics): void;
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -11,24 +11,22 @@ class Config implements ConfigInterface
 
     /**
      * Index of the user's bucket.
-     *
-     * @var int
      */
-    protected $index;
+    protected ?int $index;
 
     /**
      * Map of features.
      *
-     * @var \Zumba\Swivel\Map
+     * @var \Zumba\Swivel\Map|\Zumba\Swivel\DriverInterface
      */
-    protected $map;
+    protected $map = null;
 
     /**
      * Metrics object.
      *
      * @var \Zumba\Swivel\MetricsInterface
      */
-    protected $metrics;
+    protected ?MetricsInterface $metrics = null;
 
     /**
      * Callback to handle a missing slug from Map
@@ -39,14 +37,13 @@ class Config implements ConfigInterface
 
     /**
      * Zumba\Swivel\Config.
-     *
-     * @param mixed                         $map
-     * @param int|null                      $index
-     * @param \Psr\Log\LoggerInterface|null $logger
-     * @param callable|null                 $callback
      */
-    public function __construct($map = [], $index = null, LoggerInterface $logger = null, $callback = null)
-    {
+    public function __construct(
+        mixed $map = [],
+        ?int $index = null,
+        LoggerInterface $logger = null,
+        ?callable $callback = null
+    ) {
         $this->setLogger($logger ?: $this->getLogger());
         $this->setMap($map);
         $this->index = $index;
@@ -55,50 +52,40 @@ class Config implements ConfigInterface
 
     /**
      * Get a configured Bucket instance.
-     *
-     * @return \Zumba\Swivel\Bucket
      */
-    public function getBucket()
+    public function getBucket(): BucketInterface
     {
         return new Bucket($this->map, $this->index, $this->getLogger(), $this->callback);
     }
 
     /**
      * Get the PSR3 logger.
-     *
-     * @return \Psr\Log\LoggerInterface|null
      */
-    public function getLogger()
+    public function getLogger(): LoggerInterface
     {
         return $this->logger ?: new NullLogger();
     }
 
     /**
      * Get the Metrics object.
-     *
-     * @return \Zumba\Swivel\MetricsInterface
      */
-    public function getMetrics()
+    public function getMetrics(): ?MetricsInterface
     {
         return $this->metrics;
     }
 
     /**
      * Set the bucket index for the user.
-     *
-     * @param int $index
      */
-    public function setBucketIndex($index)
+    public function setBucketIndex(int $index): void
     {
         $this->index = $index;
     }
 
     /**
      * Set the Zumba\Swivel\Map object.
-     *
-     * @param mixed $map
      */
-    protected function setMap($map)
+    protected function setMap(mixed $map): void
     {
         $logger = $this->getLogger();
         if (is_array($map)) {
@@ -119,7 +106,7 @@ class Config implements ConfigInterface
      *
      * @param MetricsInterface $metrics
      */
-    public function setMetrics(MetricsInterface $metrics)
+    public function setMetrics(MetricsInterface $metrics): void
     {
         $this->metrics = $metrics;
     }

--- a/src/ConfigInterface.php
+++ b/src/ConfigInterface.php
@@ -2,40 +2,32 @@
 
 namespace Zumba\Swivel;
 
+use Psr\Log\LoggerInterface;
+
 interface ConfigInterface extends \Psr\Log\LoggerAwareInterface
 {
     /**
      * Get a configured Bucket instance.
-     *
-     * @return \Zumba\Swivel\Bucket
      */
-    public function getBucket();
+    public function getBucket(): BucketInterface;
 
     /**
      * Get the PSR3 logger.
-     *
-     * @return \Psr\Log\LoggerInterface
      */
-    public function getLogger();
+    public function getLogger(): LoggerInterface;
 
     /**
      * Get the Metrics object.
-     *
-     * @return \Zumba\Swivel\MetricsInterface
      */
-    public function getMetrics();
+    public function getMetrics() : ?MetricsInterface;
 
     /**
      * Set the bucket index for the user.
-     *
-     * @param int $index
      */
-    public function setBucketIndex($index);
+    public function setBucketIndex(int $index): void;
 
     /**
      * Set the Metrics object.
-     *
-     * @param MetricsInterface $metrics
      */
-    public function setMetrics(MetricsInterface $metrics);
+    public function setMetrics(MetricsInterface $metrics): void;
 }

--- a/src/DriverInterface.php
+++ b/src/DriverInterface.php
@@ -6,8 +6,6 @@ interface DriverInterface extends \Psr\Log\LoggerAwareInterface
 {
     /**
      * Generate a Zumba\Swivel\MapInterface object.
-     *
-     * @return \Zumba\Swivel\MapInterface
      */
-    public function getMap();
+    public function getMap(): MapInterface;
 }

--- a/src/Logging/NullLogger.php
+++ b/src/Logging/NullLogger.php
@@ -34,7 +34,7 @@ class NullLogger extends PsrNullLogger
      *
      * @return string Implementaiton of logger class to be passed to the Map class
      */
-    public static function __set_state($objData = array())
+    public static function __set_state($objData = [])
     {
         return new static();
     }

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -8,17 +8,13 @@ class Manager implements ManagerInterface
 
     /**
      * A configured Bucket instance.
-     *
-     * @var \Zumba\Swivel\BucketInterface
      */
-    protected $bucket;
+    protected ?BucketInterface $bucket = null;
 
     /**
      * A metrics object.
-     *
-     * @var \Zumba\Swivel\MetricsInterface
      */
-    protected $metrics;
+    protected ?MetricsInterface $metrics = null;
 
     /**
      * Zumba\Swivel\Manager.
@@ -40,13 +36,9 @@ class Manager implements ManagerInterface
     /**
      * Create a new Builder instance.
      *
-     * @param string $slug
-     *
-     * @return \Zumba\Swivel\Builder
-     *
      * @see \Zumba\Swivel\ManagerInterface
      */
-    public function forFeature($slug)
+    public function forFeature(string $slug): BuilderInterface
     {
         $this->logger->debug('Swivel - Generating builder for feature "'.$slug.'"');
         $builder = new Builder($slug, $this->bucket);
@@ -62,24 +54,15 @@ class Manager implements ManagerInterface
      *
      * Uses Builder::addBehavior
      *
-     * @param string   $slug
-     * @param callable $a
-     * @param callable $b
-     *
-     * @return mixed
-     *
      * @see \Zumba\Swivel\ManagerInterface
      */
-    public function invoke($slug, $a, $b = null)
+    public function invoke(string $slug, mixed $a, mixed $b = null): mixed
     {
-        $parts = explode(Map::DELIMITER, $slug);
-        $feature = array_shift($parts);
+        list($feature, $behavior) = explode(Map::DELIMITER, $slug, 2);
 
         return $this->forFeature($feature)
-            ->addBehavior(implode(Map::DELIMITER, $parts), $a)
-            ->defaultBehavior($b ? $b : function () use ($b) {
-                return $b;
-            })
+            ->addBehavior($behavior, $a)
+            ->defaultBehavior($b ?: fn() => $b)
             ->execute();
     }
 
@@ -88,21 +71,14 @@ class Manager implements ManagerInterface
      *
      * Uses Builder::addValue
      *
-     * @param string $slug
-     * @param mixed  $a
-     * @param mixed  $b
-     *
-     * @return mixed
-     *
      * @see \Zumba\Swivel\ManagerInterface
      */
-    public function returnValue($slug, $a, $b = null)
+    public function returnValue(string $slug, mixed $a, mixed $b = null): mixed
     {
-        $parts = explode(Map::DELIMITER, $slug);
-        $feature = array_shift($parts);
+        list($feature, $behavior) = explode(Map::DELIMITER, $slug, 2);
 
         return $this->forFeature($feature)
-            ->addValue(implode(Map::DELIMITER, $parts), $a)
+            ->addValue($behavior, $a)
             ->defaultValue($b)
             ->execute();
     }
@@ -110,13 +86,9 @@ class Manager implements ManagerInterface
     /**
      * Set the Swivel Bucket.
      *
-     * @param \Zumba\Swivel\BucketInterface $bucket
-     *
-     * @return \Zumba\Swivel\ManagerInterface
-     *
      * @see \Zumba\Swivel\ManagerInterface
      */
-    public function setBucket(BucketInterface $bucket = null)
+    public function setBucket(BucketInterface $bucket = null): ManagerInterface
     {
         if ($bucket) {
             $this->bucket = $bucket;
@@ -131,7 +103,7 @@ class Manager implements ManagerInterface
      *
      * @param MetricsInterface $metrics
      */
-    protected function setMetrics(MetricsInterface $metrics)
+    protected function setMetrics(MetricsInterface $metrics): void
     {
         $this->metrics = $metrics;
     }

--- a/src/ManagerInterface.php
+++ b/src/ManagerInterface.php
@@ -6,30 +6,16 @@ interface ManagerInterface extends \Psr\Log\LoggerAwareInterface
 {
     /**
      * Create a new Builder instance.
-     *
-     * @param string $slug
-     *
-     * @return \Zumba\Swivel\Builder
      */
-    public function forFeature($slug);
+    public function forFeature(string $slug): BuilderInterface;
 
     /**
      * Syntactic sugar for creating simple feature toggles (ternary style).
-     *
-     * @param string $slug
-     * @param mixed  $a
-     * @param mixed  $b
-     *
-     * @return mixed
      */
-    public function invoke($slug, $a, $b = null);
+    public function invoke(string $slug, mixed $a, mixed $b = null);
 
     /**
      * Set the Swivel Bucket.
-     *
-     * @param \Zumba\Swivel\BucketInterface $bucket
-     *
-     * @return \Zumba\Swivel\ManagerInterface
      */
-    public function setBucket(BucketInterface $bucket = null);
+    public function setBucket(BucketInterface $bucket = null): ManagerInterface;
 }

--- a/src/Map.php
+++ b/src/Map.php
@@ -16,7 +16,7 @@ class Map implements MapInterface
      *
      * @var array
      */
-    protected $map;
+    protected array $map;
 
     /**
      * Zumba\Swivel\Map.
@@ -39,10 +39,8 @@ class Map implements MapInterface
 
     /**
      * For serialization, removing logger since we can't guarantee a safe serialization and unserialization.
-     *
-     * @return array
      */
-    public function __sleep()
+    public function __sleep(): array
     {
         return ['map'];
     }
@@ -50,7 +48,7 @@ class Map implements MapInterface
     /**
      * Ensure a null logger is in place post unserilization so there's no issues.
      */
-    public function __wakeup()
+    public function __wakeup(): void
     {
         $this->setLogger(new NullLogger());
     }
@@ -60,12 +58,8 @@ class Map implements MapInterface
      *
      * Values in $map will be added to values in this instance.  Any number of additional maps may
      * be passed to this method, i.e. $map->merge($map2, $map3, $map4, ...);
-     *
-     * @param MapInterface $map
-     *
-     * @return MapInterface
      */
-    public function add(MapInterface $map)
+    public function add(MapInterface $map): MapInterface
     {
         $combine = function ($data, $map) {
             foreach ($map as $key => $mask) {
@@ -85,16 +79,10 @@ class Map implements MapInterface
      * SetState.
      *
      * Support reloading class via var_export definition.
-     *
-     * @param array $mapData Array of logger data needed to reconsturct logger
-     *
-     * @return string Implementaiton of logger class to be passed to the Map class
      */
-    public static function __set_state($mapData)
+    public static function __set_state($mapData): object
     {
-        $map = new static($mapData['map'], $mapData['logger']);
-
-        return $map;
+        return new static($mapData['map'], $mapData['logger']);
     }
 
     /**
@@ -105,12 +93,8 @@ class Map implements MapInterface
      * new object.
      *
      * If this map has a logger, it will be passed to the new map.
-     *
-     * @param MapInterface $map
-     *
-     * @return MapInterface
      */
-    public function diff(MapInterface $map)
+    public function diff(MapInterface $map): MapInterface
     {
         $otherMapData = $map->getMapData();
         $data = array_merge(
@@ -124,14 +108,9 @@ class Map implements MapInterface
     /**
      * Check if a feature slug is enabled for a particular bucket index.
      *
-     * @param string $slug
-     * @param int    $index
-     *
-     * @return bool
-     *
      * @see \Zumba\Swivel\MapInterface
      */
-    public function enabled($slug, $index)
+    public function enabled(string $slug, int $index): bool
     {
         $map = $this->map;
         $key = '';
@@ -155,22 +134,16 @@ class Map implements MapInterface
 
     /**
      * Check if a feature slug exists in the Map.
-     *
-     * @param string $slug
-     *
-     * @return bool
      */
-    public function slugExists($slug)
+    public function slugExists(string $slug): bool
     {
         return isset($this->map[$slug]);
     }
 
     /**
      * Get the internal map array used by this map object.
-     *
-     * @return array
      */
-    public function getMapData()
+    public function getMapData(): array
     {
         return $this->map;
     }
@@ -180,12 +153,8 @@ class Map implements MapInterface
      *
      * Returned object will contain only the elements that match between the two maps. If this map
      * has a logger, it will be passed to the new map.
-     *
-     * @param MapInterface $map
-     *
-     * @return MapInterface
      */
-    public function intersect(MapInterface $map)
+    public function intersect(MapInterface $map): MapInterface
     {
         return new self(array_intersect_assoc($this->map, $map->getMapData()), $this->logger);
     }
@@ -195,12 +164,8 @@ class Map implements MapInterface
      *
      * Values in $map will overwrite values in this instance.  Any number of additional maps may
      * be passed to this method, i.e. $map->merge($map2, $map3, $map4, ...);
-     *
-     * @param MapInterface $map
-     *
-     * @return MapInterface
      */
-    public function merge(MapInterface $map)
+    public function merge(MapInterface $map): MapInterface
     {
         $maps = array_slice(func_get_args(), 1);
         $data = array_reduce($maps, 'array_merge', array_merge($this->map, $map->getMapData()));
@@ -212,12 +177,8 @@ class Map implements MapInterface
      * Reduce an array of integers to a bitmask if $list is an array.
      *
      * Otherwise, this method will just return $list.
-     *
-     * @param mixed $list
-     *
-     * @return int bitmask
      */
-    protected function reduceToBitmask($list)
+    protected function reduceToBitmask(mixed $list): int
     {
         $this->logger->debug('Swivel - reducing to bitmask.', compact('list'));
 
@@ -231,12 +192,8 @@ class Map implements MapInterface
 
     /**
      * Parse a human readable map into a map of bitmasks.
-     *
-     * @param array $map
-     *
-     * @return array
      */
-    public function parse(array $map)
+    public function parse(array $map): array
     {
         $this->logger->info('Swivel - Parsing feature map.', compact('map'));
 

--- a/src/MapInterface.php
+++ b/src/MapInterface.php
@@ -9,12 +9,8 @@ interface MapInterface extends \Psr\Log\LoggerAwareInterface
      *
      * Values in $map will be added to values in this instance.  Any number of additional maps may
      * be passed to this method, i.e. $map->merge($map2, $map3, $map4, ...);
-     *
-     * @param MapInterface $map
-     *
-     * @return MapInterface
      */
-    public function add(MapInterface $map);
+    public function add(MapInterface $map): MapInterface;
 
     /**
      * Compare $map to this instance and return a new MapInterface.
@@ -22,60 +18,37 @@ interface MapInterface extends \Psr\Log\LoggerAwareInterface
      * Returned object will contain only the elements that differ between the two maps. If a feature
      * with the same key has different buckets, the buckets from the passed-in $map will be in the
      * new object.  If this map has a logger, it will be passed to the new map.
-     *
-     * @param MapInterface $map
-     *
-     * @return MapInterface
      */
-    public function diff(MapInterface $map);
+    public function diff(MapInterface $map): MapInterface;
 
     /**
      * Check if a feature slug is enabled for a particular bucket index.
-     *
-     * @param string $slug
-     * @param binary $index
-     *
-     * @return bool
      */
-    public function enabled($slug, $index);
+    public function enabled(string $slug, int $index): bool;
 
     /**
      * Get the internal map array used by this map object.
-     *
-     * @return array
      */
-    public function getMapData();
+    public function getMapData(): array;
 
     /**
      * Compare $map to this instance and return a new MapInterface.
      *
      * Returned object will contain only the elements that match between the two maps. If this map
      * has a logger, it will be passed to the new map.
-     *
-     * @param MapInterface $map
-     *
-     * @return MapInterface
      */
-    public function intersect(MapInterface $map);
+    public function intersect(MapInterface $map): MapInterface;
 
     /**
      * Merge this map with another map and return a new MapInterface.
      *
      * Values in $map will overwrite values in this instance.  Any number of additional maps may
      * be passed to this method, i.e. $map->merge($map2, $map3, $map4, ...);
-     *
-     * @param MapInterface $map
-     *
-     * @return MapInterface
      */
-    public function merge(MapInterface $map);
+    public function merge(MapInterface $map): MapInterface;
 
     /**
      * Parse a human readable map into a map of bitmasks.
-     *
-     * @param array $map
-     *
-     * @return array
      */
-    public function parse(array $map);
+    public function parse(array $map): array;
 }

--- a/src/MetricsInterface.php
+++ b/src/MetricsInterface.php
@@ -2,6 +2,8 @@
 
 namespace Zumba\Swivel;
 
+use Closure;
+
 interface MetricsInterface
 {
     /**
@@ -11,126 +13,68 @@ interface MetricsInterface
 
     /**
      * Send a count.
-     *
-     * @param string $context
-     * @param string $source
-     * @param int    $value
-     * @param string $metric
      */
-    public function count($context, $source, $value = 1, $metric = '');
+    public function count(string $context, string $source, int $value = 1, string $metric = ''): void;
 
     /**
      * Decrement a metric by 1.
-     *
-     * @param string $context
-     * @param string $source
-     * @param string $metric
      */
-    public function decrement($context, $source, $metric = '');
+    public function decrement(string $context, string $source, string $metric = ''): void;
 
     /**
      * End the memory profiling and send the value.
-     *
-     * @param string $context
-     * @param string $source
-     * @param string $metric
      */
-    public function endMemoryProfile($context, $source, $metric = '');
+    public function endMemoryProfile(string $context, string $source, string $metric = ''): void;
 
     /**
      * End the timing for a metric and send the value.
-     *
-     * @param string $context
-     * @param string $source
-     * @param string $metric
      */
-    public function endTiming($context, $source, $metric = '');
+    public function endTiming(string $context, string $source, string $metric = ''): void;
 
     /**
      * Send a gauged metric.
-     *
-     * @param string $context
-     * @param string $source
-     * @param int    $value
-     * @param string $metric
      */
-    public function gauge($context, $source, $value = 0, $metric = '');
+    public function gauge(string $context, string $source, int $value = 0, string $metric = ''): void;
 
     /**
      * Increment the metric by 1.
-     *
-     * @param string $context
-     * @param string $source
-     * @param string $metric
      */
-    public function increment($context, $source, $metric = '');
+    public function increment(string $context, string $source, string $metric = ''): void;
 
     /**
      * Report memory usage.
      *
      * If $memory is null, report peak usage
-     *
-     * @param string   $context
-     * @param string   $source
-     * @param int|null $memory
-     * @param string   $metric
      */
-    public function memory($context, $source, $memory = null, $metric = '');
+    public function memory(string $context, string $source, ?int $memory = null, string $metric = ''): void;
 
     /**
      * Send a unique metric.
-     *
-     * @param string $context
-     * @param string $source
-     * @param int    $value
-     * @param string $metric
      */
-    public function set($context, $source, $value = 0, $metric = '');
+    public function set(string $context, string $source, int $value = 0, string $metric = ''): void;
 
     /**
      * Set the slug namespace.
-     *
-     * @param string $namespace
      */
-    public function setNamespace($namespace = self::DEFAULT_NAMESPACE);
+    public function setNamespace(string $namespace = self::DEFAULT_NAMESPACE): void;
 
     /**
      * Start memory "profiling".
-     *
-     * @param string $context
-     * @param string $source
-     * @param string $metric
      */
-    public function startMemoryProfile($context, $source, $metric = '');
+    public function startMemoryProfile(string $context, string $source, string $metric = ''): void;
 
     /**
      * Starts timing a metric.
-     *
-     * @param string $context
-     * @param string $source
-     * @param string $metric
      */
-    public function startTiming($context, $source, $metric = '');
+    public function startTiming(string $context, string $source, string $metric = ''): void;
 
     /**
      * Execute, measure execution time, and return a \Closure's return value.
-     *
-     * @param string   $context
-     * @param string   $source
-     * @param \Closure $func
-     * @param string   $metric
-     *
-     * @return mixed
      */
-    public function time($context, $source, \Closure $func, $metric = '');
+    public function time(string $context, string $source, Closure $func, string $metric = ''): mixed;
 
     /**
      * Send a timing metric.
-     *
-     * @param string $context
-     * @param string $source
-     * @param int    $value
-     * @param string $metric
      */
-    public function timing($context, $source, $value = 0, $metric = '');
+    public function timing(string $context, string $source, int $value = 0, string $metric = ''): void;
 }

--- a/test/Tests/BehaviorTest.php
+++ b/test/Tests/BehaviorTest.php
@@ -12,7 +12,7 @@ class BehaviorTest extends TestCase
     public function testExecute()
     {
         $mock = $this->getMockBuilder(stdClass::class)
-            ->setMethods(['callback'])
+            ->addMethods(['callback'])
             ->getMock();
         $mock->expects($this->once())
             ->method('callback')
@@ -27,8 +27,7 @@ class BehaviorTest extends TestCase
     {
         $logger = $this->getMockBuilder(NullLogger::class)
             ->getMock();
-        $behavior = new Behavior('a', function () {
-        });
+        $behavior = new Behavior('a', fn() => null);
         $behavior->setLogger($logger);
 
         $logger->expects($this->once())

--- a/test/Tests/BucketTest.php
+++ b/test/Tests/BucketTest.php
@@ -12,25 +12,25 @@ class BucketTest extends TestCase
     public function testEnabledDelegatesToMap()
     {
         $map = $this->getMockBuilder(Map::class)
-            ->setMethods(['enabled'])
+            ->onlyMethods(['enabled'])
             ->getMock();
         $behavior = $this->getMockBuilder(Behavior::class)
-            ->setMethods(['getSlug'])
-            ->setConstructorArgs(['test', function () {}])
+            ->onlyMethods(['getSlug'])
+            ->setConstructorArgs(['test', fn() => null])
             ->getMock();
         $bucket = new Bucket($map, Bucket::FIFTH);
 
         $map->expects($this->once())
             ->method('enabled')
             ->with('Test.test', Bucket::FIFTH)
-            ->will($this->returnValue('test_result'));
+            ->will($this->returnValue(true));
 
         $behavior
             ->expects($this->once())
             ->method('getSlug')
             ->will($this->returnValue('Test.test'));
 
-        $this->assertSame('test_result', $bucket->enabled($behavior));
+        $this->assertTrue($bucket->enabled($behavior));
     }
 
     /**
@@ -39,12 +39,9 @@ class BucketTest extends TestCase
     public function testCallbackReceivedSlug($slug, $mapArray)
     {
         $map = new \Zumba\Swivel\Map($mapArray);
-        $behavior = new \Zumba\Swivel\Behavior($slug, function () {
-        });
+        $behavior = new \Zumba\Swivel\Behavior($slug, fn() => null);
 
-        $bucket = new Bucket($map, Bucket::FIRST, null, function ($slug_param) use ($slug) {
-            $this->assertEquals($slug, $slug_param);
-        });
+        $bucket = new Bucket($map, Bucket::FIRST, null, fn($slug_param) => $this->assertEquals($slug, $slug_param));
 
         $bucket->enabled($behavior);
     }

--- a/test/Tests/BuilderTest.php
+++ b/test/Tests/BuilderTest.php
@@ -9,6 +9,7 @@ use Zumba\Swivel\Map;
 use Psr\Log\NullLogger;
 use Zumba\Swivel\Behavior;
 use Zumba\Swivel\Bucket;
+use Zumba\Swivel\BuilderInterface;
 use Zumba\Swivel\MetricsInterface;
 
 class BuilderTest extends TestCase
@@ -70,15 +71,14 @@ class BuilderTest extends TestCase
         $map = $this->getMockBuilder(Map::class)
             ->getMock();
         $bucket = $this->getMockBuilder(Bucket::class)
-            ->setMethods(['enabled'])
+            ->onlyMethods(['enabled'])
             ->setConstructorArgs([$map])
             ->getMock();
         $builder = $this->getMockBuilder(Builder::class)
-            ->setMethods(['getBehavior'])
+            ->onlyMethods(['getBehavior'])
             ->setConstructorArgs(['Test', $bucket])
             ->getMock();
-        $strategy = function () {
-        };
+        $strategy = fn () => null;
         $behavior = $this->getMockBuilder(Behavior::class)
             ->setConstructorArgs(['a', $strategy])
             ->getMock();
@@ -95,7 +95,7 @@ class BuilderTest extends TestCase
             ->with($behavior)
             ->will($this->returnValue(false));
 
-        $this->assertInstanceOf('Zumba\Swivel\BuilderInterface', $builder->addBehavior('a', $strategy));
+        $this->assertInstanceOf(BuilderInterface::class, $builder->addBehavior('a', $strategy));
     }
 
     public function testAddBehaviorEnabled()
@@ -103,16 +103,15 @@ class BuilderTest extends TestCase
         $map = $this->getMockBuilder(Map::class)
             ->getMock();
         $bucket = $this->getMockBuilder(Bucket::class)
-            ->setMethods(['enabled'])
+            ->onlyMethods(['enabled'])
             ->setConstructorArgs([$map])
             ->getMock();
         $builder = $this->getMockBuilder(Builder::class)
-            ->setMethods(['getBehavior', 'setBehavior'])
+            ->onlyMethods(['getBehavior', 'setBehavior'])
             ->setConstructorArgs(['Test', $bucket])
             ->getMock();
 
-        $strategy = function () {
-        };
+        $strategy = fn() => null;
         $behavior = $this->getMockBuilder(Behavior::class)
             ->setConstructorArgs(['a', $strategy])
             ->getMock();
@@ -134,7 +133,7 @@ class BuilderTest extends TestCase
             ->with($behavior)
             ->will($this->returnValue(true));
 
-        $this->assertInstanceOf('Zumba\Swivel\BuilderInterface', $builder->addBehavior('a', $strategy));
+        $this->assertInstanceOf(BuilderInterface::class, $builder->addBehavior('a', $strategy));
     }
 
     public function testAddValueNotEnabled()
@@ -142,19 +141,17 @@ class BuilderTest extends TestCase
         $map = $this->getMockBuilder(Map::class)
             ->getMock();
         $bucket = $this->getMockBuilder(Bucket::class)
-            ->setMethods(['enabled'])
+            ->onlyMethods(['enabled'])
             ->setConstructorArgs([$map])
             ->getMock();
         $builder = $this->getMockBuilder(Builder::class)
-            ->setMethods(['getBehavior'])
+            ->onlyMethods(['getBehavior'])
             ->setConstructorArgs(['Test', $bucket])
             ->getMock();
         $value = null;
         $behavior = $this->getMockBuilder(Behavior::class)
             ->setConstructorArgs([
-                'a', function () use ($value) {
-                    return $value;
-                },
+                'a', fn() => $value,
             ])
             ->getMock();
 
@@ -170,7 +167,7 @@ class BuilderTest extends TestCase
             ->with($behavior)
             ->will($this->returnValue(false));
 
-        $this->assertInstanceOf('Zumba\Swivel\BuilderInterface', $builder->addValue('a', $value));
+        $this->assertInstanceOf(BuilderInterface::class, $builder->addValue('a', $value));
     }
 
     public function testAddValueEnabled()
@@ -178,20 +175,18 @@ class BuilderTest extends TestCase
         $map = $this->getMockBuilder(Map::class)
             ->getMock();
         $bucket = $this->getMockBuilder(Bucket::class)
-            ->setMethods(['enabled'])
+            ->onlyMethods(['enabled'])
             ->setConstructorArgs([$map])
             ->getMock();
         $builder = $this->getMockBuilder(Builder::class)
-            ->setMethods(['getBehavior', 'setBehavior'])
+            ->onlyMethods(['getBehavior', 'setBehavior'])
             ->setConstructorArgs(['Test', $bucket])
             ->getMock();
 
         $value = null;
         $behavior = $this->getMockBuilder(Behavior::class)
             ->setConstructorArgs([
-                'a', function () use ($value) {
-                    return $value;
-                },
+                'a', fn() => $value,
             ])
             ->getMock();
 
@@ -213,7 +208,7 @@ class BuilderTest extends TestCase
             ->with($behavior)
             ->will($this->returnValue(true));
 
-        $this->assertInstanceOf('Zumba\Swivel\BuilderInterface', $builder->addValue('a', $value));
+        $this->assertInstanceOf(BuilderInterface::class, $builder->addValue('a', $value));
     }
 
     public function testDefaultBehavior()
@@ -224,11 +219,10 @@ class BuilderTest extends TestCase
             ->setConstructorArgs([$map])
             ->getMock();
         $builder = $this->getMockBuilder(Builder::class)
-            ->setMethods(['getBehavior'])
+            ->onlyMethods(['getBehavior'])
             ->setConstructorArgs(['Test', $bucket])
             ->getMock();
-        $strategy = function () {
-        };
+        $strategy = fn() => null;
         $behavior = $this->getMockBuilder(Behavior::class)
             ->setConstructorArgs([Builder::DEFAULT_SLUG, $strategy])
             ->getMock();
@@ -240,7 +234,7 @@ class BuilderTest extends TestCase
             ->will($this->returnValue($behavior));
 
         $builder->setLogger(new NullLogger());
-        $this->assertInstanceOf('Zumba\Swivel\BuilderInterface', $builder->defaultBehavior($strategy));
+        $this->assertInstanceOf(BuilderInterface::class, $builder->defaultBehavior($strategy));
     }
 
     public function testDefaultValue()
@@ -251,16 +245,14 @@ class BuilderTest extends TestCase
             ->setConstructorArgs([$map])
             ->getMock();
         $builder = $this->getMockBuilder(Builder::class)
-            ->setMethods(['getBehavior'])
+            ->onlyMethods(['getBehavior'])
             ->setConstructorArgs(['Test', $bucket])
             ->getMock();
         $value = null;
         $behavior = $this->getMockBuilder(Behavior::class)
             ->setConstructorArgs([
                 Builder::DEFAULT_SLUG,
-                function () use ($value) {
-                    return $value;
-                },
+                fn() => $value,
             ])
             ->getMock();
 
@@ -271,7 +263,7 @@ class BuilderTest extends TestCase
             ->will($this->returnValue($behavior));
 
         $builder->setLogger(new NullLogger());
-        $this->assertInstanceOf('Zumba\Swivel\BuilderInterface', $builder->defaultValue(null));
+        $this->assertInstanceOf(BuilderInterface::class, $builder->defaultValue(null));
     }
 
     public function testDefaultBehaviorThrowsIfNoDefaultCalledFirst()
@@ -286,8 +278,7 @@ class BuilderTest extends TestCase
         $builder = new Builder('Test', $bucket);
         $builder->setLogger(new NullLogger());
         $builder->noDefault();
-        $builder->defaultBehavior(function () {
-        });
+        $builder->defaultBehavior(fn() => null);
     }
 
     public function testDefaultValueThrowsIfNoDefaultCalledFirst()
@@ -315,13 +306,12 @@ class BuilderTest extends TestCase
             ->setConstructorArgs([$map])
             ->getMock();
         $builder = $this->getMockBuilder(Builder::class)
-            ->setMethods(['getBehavior'])
+            ->onlyMethods(['getBehavior'])
             ->setConstructorArgs(['Test', $bucket])
             ->getMock();
-        $strategy = function () {
-        };
+        $strategy = fn() => null;
         $behavior = $this->getMockBuilder(Behavior::class)
-            ->setMethods(['getSlug'])
+            ->onlyMethods(['getSlug'])
             ->setConstructorArgs([Builder::DEFAULT_SLUG, $strategy])
             ->getMock();
 
@@ -350,17 +340,15 @@ class BuilderTest extends TestCase
             ->setConstructorArgs([$map])
             ->getMock();
         $builder = $this->getMockBuilder(Builder::class)
-            ->setMethods(['getBehavior'])
+            ->onlyMethods(['getBehavior'])
             ->setConstructorArgs(['Test', $bucket])
             ->getMock();
         $value = 'test';
         $behavior = $this->getMockBuilder(Behavior::class)
-            ->setMethods(['getSlug'])
+            ->onlyMethods(['getSlug'])
             ->setConstructorArgs([
                 Builder::DEFAULT_SLUG,
-                function () use ($value) {
-                    return $value;
-                },
+                fn() => $value,
             ])
             ->getMock();
 
@@ -388,10 +376,7 @@ class BuilderTest extends TestCase
             ->getMock();
         $builder->setMetrics($metrics);
         $builder->setLogger(new NullLogger());
-        $builder->defaultBehavior(function () {
-            return 'abc';
-
-        });
+        $builder->defaultBehavior(fn() => 'abc');
         $this->assertSame('abc', $builder->execute());
     }
 
@@ -403,8 +388,7 @@ class BuilderTest extends TestCase
             ->setConstructorArgs([$map])
             ->getMock();
         $builder = new Builder('Test', $bucket);
-        $strategy = function () {
-        };
+        $strategy = fn() => null;
 
         $metrics = $this->getMockBuilder(MetricsInterface::class)
             ->getMock();
@@ -412,11 +396,11 @@ class BuilderTest extends TestCase
         $builder->setLogger(new NullLogger());
 
         $behavior = $builder->getBehavior('a', $strategy);
-        $this->assertInstanceOf('Zumba\Swivel\Behavior', $behavior);
+        $this->assertInstanceOf(Behavior::class, $behavior);
         $this->assertSame('Test'.Map::DELIMITER.'a', $behavior->getSlug());
 
         $behavior = $builder->getBehavior('', $strategy);
-        $this->assertInstanceOf('Zumba\Swivel\Behavior', $behavior);
+        $this->assertInstanceOf(Behavior::class, $behavior);
         $this->assertSame('Test', $behavior->getSlug());
 
     }
@@ -436,7 +420,7 @@ class BuilderTest extends TestCase
         $builder->setMetrics($metrics);
         $builder->setLogger(new NullLogger());
         $behavior = $builder->getBehavior('a', $strategy);
-        $this->assertInstanceOf('Zumba\Swivel\Behavior', $behavior);
+        $this->assertInstanceOf(Behavior::class, $behavior);
         $this->assertSame('Test'.Map::DELIMITER.'a', $behavior->getSlug());
 
         $this->assertEquals(
@@ -461,7 +445,7 @@ class BuilderTest extends TestCase
         $builder->setMetrics($metrics);
         $builder->setLogger(new NullLogger());
         $behavior = $builder->getBehavior('a', $strategy);
-        $this->assertInstanceOf('Zumba\Swivel\Behavior', $behavior);
+        $this->assertInstanceOf(Behavior::class, $behavior);
         $this->assertSame('Test'.Map::DELIMITER.'a', $behavior->getSlug());
 
         $this->assertEquals(
@@ -486,7 +470,7 @@ class BuilderTest extends TestCase
         $builder->setMetrics($metrics);
         $builder->setLogger(new NullLogger());
         $behavior = $builder->getBehavior('a', $strategy);
-        $this->assertInstanceOf('Zumba\Swivel\Behavior', $behavior);
+        $this->assertInstanceOf(Behavior::class, $behavior);
         $this->assertSame('Test'.Map::DELIMITER.'a', $behavior->getSlug());
 
         $this->assertEquals(
@@ -511,7 +495,7 @@ class BuilderTest extends TestCase
         $builder->setMetrics($metrics);
         $builder->setLogger(new NullLogger());
         $behavior = $builder->getBehavior('a', $strategy);
-        $this->assertInstanceOf('Zumba\Swivel\Behavior', $behavior);
+        $this->assertInstanceOf(Behavior::class, $behavior);
         $this->assertSame('Test'.Map::DELIMITER.'a', $behavior->getSlug());
 
         $this->assertEquals(

--- a/test/Tests/ConfigTest.php
+++ b/test/Tests/ConfigTest.php
@@ -4,6 +4,7 @@ namespace Tests;
 
 use LogicException;
 use PHPUnit\Framework\TestCase;
+use Zumba\Swivel\Bucket;
 use Zumba\Swivel\Config;
 use Zumba\Swivel\DriverInterface;
 use Zumba\Swivel\MapInterface;
@@ -13,10 +14,9 @@ class ConfigTest extends TestCase
 {
     public function testGetBucket()
     {
-        $index = 4;
         $config = new Config(['A' => [7, 8, 9]], 4);
         $bucket = $config->getBucket();
-        $this->assertInstanceOf('Zumba\Swivel\Bucket', $bucket);
+        $this->assertInstanceOf(Bucket::class, $bucket);
     }
 
     public function testSetBucketIndex()

--- a/test/Tests/Integration/SwivelTest.php
+++ b/test/Tests/Integration/SwivelTest.php
@@ -33,12 +33,8 @@ class SwivelTest extends TestCase
     {
         $swivel = new Manager(new Config($this->map, 4));
         $result = $swivel->forFeature('System')
-            ->addBehavior('NewAlgorithm', function () {
-                return 'NewHotness';
-            })
-            ->defaultBehavior(function () {
-                return 'OldAndBusted';
-            })
+            ->addBehavior('NewAlgorithm', fn() => 'NewHotness')
+            ->defaultBehavior(fn() => 'OldAndBusted')
             ->execute();
 
         $this->assertSame('NewHotness', $result);
@@ -48,12 +44,8 @@ class SwivelTest extends TestCase
     {
         $swivel = new Manager(new Config($this->map, 9));
         $result = $swivel->forFeature('System')
-            ->addBehavior('NewAlgorithm', function () {
-                return 'NewHotness';
-            })
-            ->defaultBehavior(function () {
-                return 'OldAndBusted';
-            })
+            ->addBehavior('NewAlgorithm', fn() => 'NewHotness')
+            ->defaultBehavior(fn() => 'OldAndBusted')
             ->execute();
 
         $this->assertSame('OldAndBusted', $result);
@@ -77,12 +69,8 @@ class SwivelTest extends TestCase
     {
         $swivel = new Manager(new Config($this->map, $bucket));
         $result = $swivel->forFeature('OldFeature')
-            ->addBehavior('Legacy', function () {
-                return 'AlwaysOn';
-            })
-            ->defaultBehavior(function () {
-                return 'NeverOn';
-            })
+            ->addBehavior('Legacy', fn() => 'AlwaysOn')
+            ->defaultBehavior(fn() => 'NeverOn')
             ->execute();
 
         $this->assertSame('AlwaysOn', $result);
@@ -95,12 +83,8 @@ class SwivelTest extends TestCase
     {
         $swivel = new Manager(new Config($this->map, $bucket));
         $result = $swivel->forFeature('BadIdea')
-            ->addBehavior('Implementation', function () {
-                return 'IsOn?';
-            })
-            ->defaultBehavior(function () {
-                return 'NeverOn';
-            })
+            ->addBehavior('Implementation', fn() => 'IsOn?')
+            ->defaultBehavior(fn() => 'NeverOn')
             ->execute();
 
         $this->assertSame('NeverOn', $result);
@@ -110,12 +94,8 @@ class SwivelTest extends TestCase
     {
         $swivel = new Manager(new Config($this->map, 1));
         $result = $swivel->forFeature('ParentOff')
-            ->addBehavior('ChildOn', function () {
-                return 'NeverWorks';
-            })
-            ->defaultBehavior(function () {
-                return 'AlwaysDefault';
-            })
+            ->addBehavior('ChildOn', fn() => 'NeverWorks')
+            ->defaultBehavior(fn() => 'AlwaysDefault')
             ->execute();
 
         $this->assertSame('AlwaysDefault', $result);
@@ -126,14 +106,8 @@ class SwivelTest extends TestCase
      */
     public function testBranchingChildren($bucket, $assertOne, $assertTwo, $assertThree, $assertFour)
     {
-        $on = function () {
-            return true;
-
-        };
-        $off = function () {
-            return false;
-
-        };
+        $on = fn() => true;
+        $off = fn() => false;
         $swivel = new Manager(new Config($this->map, $bucket));
         $result = $swivel->forFeature('NewFeature')
             ->addBehavior('SimpleStuff', $on)
@@ -169,12 +143,8 @@ class SwivelTest extends TestCase
         $swivel = new Manager(new Config($this->map, 1));
         $result = $swivel->invoke(
             'System.NewAlgorithm',
-            function () {
-                return 'NewHotness';
-            },
-            function () {
-                return 'OldAndBusted';
-            }
+            fn() => 'NewHotness',
+            fn() => 'OldAndBusted'
         );
         $this->assertSame('NewHotness', $result);
     }
@@ -184,12 +154,8 @@ class SwivelTest extends TestCase
         $swivel = new Manager(new Config($this->map, 10));
         $result = $swivel->invoke(
             'System.NewAlgorithm',
-            function () {
-                return 'NewHotness';
-            },
-            function () {
-                return 'OldAndBusted';
-            }
+            fn() => 'NewHotness',
+            fn() => 'OldAndBusted'
         );
         $this->assertSame('OldAndBusted', $result);
     }
@@ -197,20 +163,14 @@ class SwivelTest extends TestCase
     public function testInvokeSystemNewAlgorithmValidBucketNoDefault()
     {
         $swivel = new Manager(new Config($this->map, 1));
-        $result = $swivel->invoke('System.NewAlgorithm', function () {
-            return 'NewHotness';
-
-        });
+        $result = $swivel->invoke('System.NewAlgorithm', fn() => 'NewHotness');
         $this->assertSame('NewHotness', $result);
     }
 
     public function testInvokeSystemNewAlgorithmInvalidBucketNoDefault()
     {
         $swivel = new Manager(new Config($this->map, 10));
-        $result = $swivel->invoke('System.NewAlgorithm', function () {
-            return 'NewHotness';
-
-        });
+        $result = $swivel->invoke('System.NewAlgorithm', fn() => 'NewHotness');
         $this->assertSame(null, $result);
     }
 
@@ -218,9 +178,7 @@ class SwivelTest extends TestCase
     {
         $swivel = new Manager(new Config($this->map, 2));
         $result = $swivel->forFeature('System')
-            ->addBehavior('NewAlgorithm', function () {
-                return 'NewHotness';
-            })
+            ->addBehavior('NewAlgorithm', fn() => 'NewHotness')
             ->noDefault()
             ->execute();
 
@@ -231,9 +189,7 @@ class SwivelTest extends TestCase
     {
         $swivel = new Manager(new Config($this->map, 8));
         $result = $swivel->forFeature('System')
-            ->addBehavior('NewAlgorithm', function () {
-                return 'NewHotness';
-            })
+            ->addBehavior('NewAlgorithm', fn() => 'NewHotness')
             ->noDefault()
             ->execute();
 
@@ -246,9 +202,7 @@ class SwivelTest extends TestCase
     public function testFalseyValuesAllowedInBehaviors($falseyValue)
     {
         $swivel = new Manager(new Config($this->map, 10));
-        $this->assertSame($falseyValue, $swivel->invoke('OldFeature.Legacy', function () use ($falseyValue) {
-            return $falseyValue;
-        }));
+        $this->assertSame($falseyValue, $swivel->invoke('OldFeature.Legacy', fn() => $falseyValue));
     }
 
     /**

--- a/test/Tests/ManagerTest.php
+++ b/test/Tests/ManagerTest.php
@@ -4,6 +4,7 @@ namespace Tests;
 
 use PHPUnit\Framework\TestCase;
 use Zumba\Swivel\Bucket;
+use Zumba\Swivel\Builder;
 use Zumba\Swivel\Manager;
 use Zumba\Swivel\Config;
 use Zumba\Swivel\Map;
@@ -21,7 +22,7 @@ class ManagerTest extends TestCase
             ->getMock();
 
         $manager->setBucket($bucket);
-        $this->assertInstanceOf('Zumba\Swivel\Builder', $manager->forFeature('Test'));
+        $this->assertInstanceOf(Builder::class, $manager->forFeature('Test'));
     }
 
     public function testSetBucketReturnsManager()
@@ -32,18 +33,18 @@ class ManagerTest extends TestCase
         $bucket = $this->getMockBuilder(Bucket::class)
             ->setConstructorArgs([$map])
             ->getMock();
-        $this->assertInstanceOf('Zumba\Swivel\Manager', $manager->setBucket($bucket));
+        $this->assertInstanceOf(Manager::class, $manager->setBucket($bucket));
     }
 
     public function testInvokeOneParamEnabled()
     {
         $config = new Config();
         $manager = $this->getMockBuilder(Manager::class)
-            ->setMethods(['forFeature'])
+            ->onlyMethods(['forFeature'])
             ->setConstructorArgs([$config])
             ->getMock();
         $builder = $this
-            ->getMockBuilder('Zumba\Swivel\Builder')
+            ->getMockBuilder(Builder::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -70,22 +71,19 @@ class ManagerTest extends TestCase
             ->method('execute')
             ->will($this->returnValue('abc'));
 
-        $this->assertEquals('abc', $manager->invoke('Test.version.a', function () {
-            return 'abc';
-
-        }));
+        $this->assertEquals('abc', $manager->invoke('Test.version.a', fn() => 'abc'));
     }
 
     public function testInvokeOneParamDisabled()
     {
         $config = new Config();
         $manager = $this->getMockBuilder(Manager::class)
-            ->setMethods(['forFeature'])
+            ->onlyMethods(['forFeature'])
             ->setConstructorArgs([$config])
             ->getMock();
 
         $builder = $this
-            ->getMockBuilder('Zumba\Swivel\Builder')
+            ->getMockBuilder(Builder::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -111,22 +109,19 @@ class ManagerTest extends TestCase
             ->expects($this->once())
             ->method('execute');
 
-        $this->assertEquals(null, $manager->invoke('Test.version.a', function () {
-            return 'abc';
-
-        }));
+        $this->assertEquals(null, $manager->invoke('Test.version.a', fn() => 'abc'));
     }
 
     public function testInvokeTwoParamEnabled()
     {
         $config = new Config();
         $manager = $this->getMockBuilder(Manager::class)
-            ->setMethods(['forFeature'])
+            ->onlyMethods(['forFeature'])
             ->setConstructorArgs([$config])
             ->getMock();
 
         $builder = $this
-            ->getMockBuilder('Zumba\Swivel\Builder')
+            ->getMockBuilder(Builder::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -155,12 +150,8 @@ class ManagerTest extends TestCase
 
         $this->assertEquals('abc', $manager->invoke(
             'Test.version.a',
-            function () {
-                return 'abc';
-            },
-            function () {
-                return 'default';
-            }
+            fn() => 'abc',
+            fn() => 'default'
         ));
     }
 
@@ -168,12 +159,12 @@ class ManagerTest extends TestCase
     {
         $config = new Config();
         $manager = $this->getMockBuilder(Manager::class)
-            ->setMethods(['forFeature'])
+            ->onlyMethods(['forFeature'])
             ->setConstructorArgs([$config])
             ->getMock();
 
         $builder = $this
-            ->getMockBuilder('Zumba\Swivel\Builder')
+            ->getMockBuilder(Builder::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -202,19 +193,15 @@ class ManagerTest extends TestCase
 
         $this->assertEquals('default', $manager->invoke(
             'Test.version.a',
-            function () {
-                return 'abc';
-            },
-            function () {
-                return 'default';
-            }
+            fn() => 'abc',
+            fn() => 'default'
         ));
     }
 
     public function testSetMetrics()
     {
         $config = $this->getMockBuilder(Config::class)
-            ->setMethods(['getMetrics'])
+            ->onlyMethods(['getMetrics'])
             ->getMock();
         $metricsInstance = $this->getMockBuilder(MetricsInterface::class)
             ->getMock();
@@ -235,12 +222,12 @@ class ManagerTest extends TestCase
     {
         $config = new Config();
         $manager = $this->getMockBuilder(Manager::class)
-            ->setMethods(['forFeature'])
+            ->onlyMethods(['forFeature'])
             ->setConstructorArgs([$config])
             ->getMock();
 
         $builder = $this
-            ->getMockBuilder('Zumba\Swivel\Builder')
+            ->getMockBuilder(Builder::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -274,12 +261,12 @@ class ManagerTest extends TestCase
     {
         $config = new Config();
         $manager = $this->getMockBuilder(Manager::class)
-            ->setMethods(['forFeature'])
+            ->onlyMethods(['forFeature'])
             ->setConstructorArgs([$config])
             ->getMock();
 
         $builder = $this
-            ->getMockBuilder('Zumba\Swivel\Builder')
+            ->getMockBuilder(Builder::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -312,12 +299,12 @@ class ManagerTest extends TestCase
     {
         $config = new Config();
         $manager = $this->getMockBuilder(Manager::class)
-            ->setMethods(['forFeature'])
+            ->onlyMethods(['forFeature'])
             ->setConstructorArgs([$config])
             ->getMock();
 
         $builder = $this
-            ->getMockBuilder('Zumba\Swivel\Builder')
+            ->getMockBuilder(Builder::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -351,12 +338,12 @@ class ManagerTest extends TestCase
     {
         $config = new Config();
         $manager = $this->getMockBuilder(Manager::class)
-            ->setMethods(['forFeature'])
+            ->onlyMethods(['forFeature'])
             ->setConstructorArgs([$config])
             ->getMock();
 
         $builder = $this
-            ->getMockBuilder('Zumba\Swivel\Builder')
+            ->getMockBuilder(Builder::class)
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/test/Tests/MapTest.php
+++ b/test/Tests/MapTest.php
@@ -3,6 +3,7 @@
 namespace Tests;
 
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Zumba\Swivel\Map;
 use Zumba\Swivel\Bucket;
 
@@ -27,7 +28,7 @@ class MapTest extends TestCase
         $loggerReflProperty = $reflObject->getProperty('logger');
         $loggerReflProperty->setAccessible(true);
         $logger = $loggerReflProperty->getValue($map);
-        $this->assertInstanceOf('\Psr\Log\LoggerInterface', $logger);
+        $this->assertInstanceOf(LoggerInterface::class, $logger);
     }
 
     /**

--- a/test/Tests/NullLoggerTest.php
+++ b/test/Tests/NullLoggerTest.php
@@ -10,12 +10,12 @@ class NullLoggerTest extends TestCase
     public function testSetStateNoData()
     {
         $nullLogger = NullLogger::__set_state([]);
-        $this->assertInstanceOf('\Zumba\Swivel\Logging\NullLogger', $nullLogger);
+        $this->assertInstanceOf(NullLogger::class, $nullLogger);
     }
 
     public function testSetStateData()
     {
         $nullLogger = NullLogger::__set_state(['some' => 'data']);
-        $this->assertInstanceOf('\Zumba\Swivel\Logging\NullLogger', $nullLogger);
+        $this->assertInstanceOf(NullLogger::class, $nullLogger);
     }
 }


### PR DESCRIPTION
* Using newer libraries
* Strict type signatures
* Changed the use of callables (replaced `call_user_func*` methods).
* PHP 8.0+ is used by about 90-95% of the users (https://packagist.org/packages/zumba/swivel/php-stats#4)